### PR TITLE
Fix getting links from javadoc.io

### DIFF
--- a/src/main/java/io/freefair/gradle/plugins/javadoc/ConfigureJavadocLinks.java
+++ b/src/main/java/io/freefair/gradle/plugins/javadoc/ConfigureJavadocLinks.java
@@ -68,7 +68,7 @@ public class ConfigureJavadocLinks extends DefaultTask {
                     break;
                 } else {
                     getLogger().info("Using javadoc.io link for '{}:{}:{}'", group, artifact, version);
-                    String javadocIoLink = String.format("%s://static.javadoc.io/%s/%s/%s/", protocol, group, artifact, version);
+                    String javadocIoLink = String.format("%s://www.javadoc.io/doc/%s/%s/%s/", protocol, group, artifact, version);
                     addLink(javadocIoLink);
                 }
             }


### PR DESCRIPTION
The base URL is not `static.javadoc.io/`, but instead `www.javadoc.io/doc/`.

The other link is not reachable. See https://www.javadoc.io/