### PR TITLE
Fix incremental build with post-compile-weaving plugin

### DIFF
--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AjcAction.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AjcAction.java
@@ -32,6 +32,8 @@ public class AjcAction implements Action<Task> {
 
     private final AspectJCompileOptions options;
 
+    private final ConfigurableFileCollection additionalInpath;
+
     public void options(Action<AspectJCompileOptions> action) {
         action.execute(getOptions());
     }
@@ -43,6 +45,7 @@ public class AjcAction implements Action<Task> {
     public AjcAction(ObjectFactory objectFactory, JavaExecHandleFactory javaExecHandleFactory) {
         options = new AspectJCompileOptions(objectFactory);
         classpath = objectFactory.fileCollection();
+        additionalInpath = objectFactory.fileCollection();
 
         enabled = objectFactory.property(Boolean.class).convention(true);
         this.javaExecHandleFactory = javaExecHandleFactory;
@@ -63,7 +66,7 @@ public class AjcAction implements Action<Task> {
                 .withNormalizer(ClasspathNormalizer.class)
                 .optional(true);
 
-        task.getInputs().files(this.getOptions().getInpath())
+        task.getInputs().files(this.getAdditionalInpath())
                 .withPropertyName("ajcInpath")
                 .withNormalizer(ClasspathNormalizer.class)
                 .optional(true);

--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AjcAction.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AjcAction.java
@@ -66,7 +66,7 @@ public class AjcAction implements Action<Task> {
                 .withNormalizer(ClasspathNormalizer.class)
                 .optional(true);
 
-        task.getInputs().files(this.getAdditionalInpath())
+        task.getInputs().files(this.getOptions().getInpath())
                 .withPropertyName("ajcInpath")
                 .withNormalizer(ClasspathNormalizer.class)
                 .optional(true);
@@ -101,6 +101,7 @@ public class AjcAction implements Action<Task> {
 
         spec.setAspectJClasspath(getClasspath());
         spec.setAspectJCompileOptions(getOptions());
+        spec.setAdditionalInpath(getAdditionalInpath());
 
         return spec;
     }

--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AspectJPostCompileWeavingPlugin.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AspectJPostCompileWeavingPlugin.java
@@ -89,6 +89,7 @@ public class AspectJPostCompileWeavingPlugin implements Plugin<Project> {
         action.getOptions().getAspectpath().from(aspectpath);
         action.getOptions().getInpath().from(abstractCompile.getDestinationDir());
         action.getOptions().getInpath().from(inpath);
+        action.getAdditionalInpath().from(inpath);
         action.getClasspath().from(aspectjConfiguration);
 
         action.addToTask(abstractCompile);

--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AspectJPostCompileWeavingPlugin.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AspectJPostCompileWeavingPlugin.java
@@ -87,9 +87,8 @@ public class AspectJPostCompileWeavingPlugin implements Plugin<Project> {
         AjcAction action = project.getObjects().newInstance(AjcAction.class);
 
         action.getOptions().getAspectpath().from(aspectpath);
-        action.getOptions().getInpath().from(abstractCompile.getDestinationDir());
         action.getOptions().getInpath().from(inpath);
-        action.getAdditionalInpath().from(inpath);
+        action.getAdditionalInpath().from(abstractCompile.getDestinationDir());
         action.getClasspath().from(aspectjConfiguration);
 
         action.addToTask(abstractCompile);

--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/internal/AspectJCompileSpec.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/internal/AspectJCompileSpec.java
@@ -12,4 +12,6 @@ public class AspectJCompileSpec extends DefaultJvmLanguageCompileSpec {
     private FileCollection aspectJClasspath;
 
     AspectJCompileOptions aspectJCompileOptions;
+
+    private FileCollection additionalInpath;
 }

--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/internal/AspectJCompiler.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/internal/AspectJCompiler.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import okio.BufferedSink;
 import okio.Okio;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.compile.CompilationFailedException;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
@@ -16,6 +17,7 @@ import org.gradle.process.internal.JavaExecHandleFactory;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,9 +51,19 @@ public class AspectJCompiler implements Compiler<AspectJCompileSpec> {
 
         List<String> args = new LinkedList<>();
 
+        Collection<File> inpath = new LinkedHashSet<>();
+
+        if (spec.getAdditionalInpath() != null && !spec.getAdditionalInpath().isEmpty()) {
+            inpath.addAll(spec.getAdditionalInpath().getFiles());
+        }
+
         if (!spec.getAspectJCompileOptions().getInpath().isEmpty()) {
+            inpath.addAll(spec.getAspectJCompileOptions().getInpath().getFiles());
+        }
+
+        if (!inpath.isEmpty()) {
             args.add("-inpath");
-            args.add(getAsPath(spec.getAspectJCompileOptions().getInpath().getFiles()));
+            args.add(getAsPath(inpath));
         }
 
         if (!spec.getAspectJCompileOptions().getAspectpath().isEmpty()) {

--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/internal/AspectJCompiler.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/internal/AspectJCompiler.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import okio.BufferedSink;
 import okio.Okio;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.tasks.compile.CompilationFailedException;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;


### PR DESCRIPTION
The post-compile-weaving plugin was incorrectly adding the compiler output directory to the _task inputs_ for modified compile tasks. This prevents the task from being
marked as UP-TO-DATE after an initial `clean compile`.

 
This fix removes the compiler output directory from the inputs of the modified
compile tasks. Instead, only files added to the `inpath` parameter are considered
to be task inputs. Both the compiler output and the configured `inpath` are still
passed to AJC via the `—inpath` property.

This PR fixes freefair/gradle-plugins#212.