### PR TITLE
Make lombok.config input use relative path sensitivity

### DIFF
--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -11,6 +11,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.quality.CodeQualityExtension;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -61,15 +62,19 @@ public class LombokPlugin implements Plugin<Project> {
             TaskProvider<JavaCompile> compileTaskProvider = project.getTasks().named(sourceSet.getCompileJavaTaskName(), JavaCompile.class, compileJava -> {
                 compileJava.dependsOn(generateLombokConfig);
                 compileJava.getOptions().getCompilerArgs().add("-Xlint:-processing");
-                compileJava.getInputs().file((Callable<RegularFileProperty>) () -> {
-                    GenerateLombokConfig generateLombokConfig = this.generateLombokConfig.get();
-                    if (generateLombokConfig.isEnabled()) {
-                        return generateLombokConfig.getOutputFile();
-                    }
-                    else {
-                        return null;
-                    }
-                }).withPropertyName("lombok.config").optional();
+                compileJava.getInputs()
+                        .file((Callable<RegularFileProperty>) () -> {
+                            GenerateLombokConfig generateLombokConfig = this.generateLombokConfig.get();
+                            if (generateLombokConfig.isEnabled()) {
+                                return generateLombokConfig.getOutputFile();
+                            }
+                            else {
+                                return null;
+                            }
+                        })
+                        .withPropertyName("lombok.config")
+                        .withPathSensitivity(PathSensitivity.RELATIVE)
+                        .optional();
             });
 
             project.afterEvaluate(p -> {


### PR DESCRIPTION
Currently, the lombok.config input on the java compile tasks uses absolute path sensitivity, which causes a build cache miss when the project is relocated (or is being built on a different machine with a different absolute path).  This change makes that input use relative path sensitivity which means the input will only hash differently if the path changes relative to the root project directory.

