### PR TITLE
add spotbugs dependencies sooner

### DIFF
--- a/examples/lombok/build.gradle
+++ b/examples/lombok/build.gradle
@@ -2,6 +2,7 @@ import io.freefair.gradle.plugins.lombok.tasks.LombokApiJar
 import io.freefair.gradle.plugins.lombok.tasks.LombokRuntimeJar
 plugins {
     id "com.github.spotbugs" version "4.0.4"
+    id "com.benjaminsproule.swagger" version "1.0.5" // reproduces error when adding dependencies in afterEvaluate
 }
 
 apply plugin: "java"


### PR DESCRIPTION
waiting until afterEvaluate to add a dependencies can easily cause an error such as `Cannot change dependencies of configuration ':compileOnly' after it has been included in dependency resolution.` when other plugins are present