### PR TITLE
Replace deprecated JavaExec.main usages with JavaExec.mainClass property

### DIFF
--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/internal/AspectJCompiler.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/internal/AspectJCompiler.java
@@ -40,7 +40,7 @@ public class AspectJCompiler implements Compiler<AspectJCompileSpec> {
         JavaExecHandleBuilder ajc = javaExecHandleFactory.newJavaExec();
         ajc.setWorkingDir(spec.getWorkingDir());
         ajc.setClasspath(spec.getAspectJClasspath());
-        ajc.setMain("org.aspectj.tools.ajc.Main");
+        ajc.getMainClass().set("org.aspectj.tools.ajc.Main");
 
         AjcForkOptions forkOptions = spec.getAspectJCompileOptions().getForkOptions();
 

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/Delombok.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/Delombok.java
@@ -176,7 +176,7 @@ public class Delombok extends DefaultTask implements LombokTask {
 
         getProject().javaexec(delombok -> {
             delombok.setClasspath(getLombokClasspath());
-            delombok.setMain("lombok.launch.Main");
+            delombok.getMainClass().set("lombok.launch.Main");
             delombok.args("delombok");
 
             delombok.args("@" + optionsFile);

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokApiJar.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokApiJar.java
@@ -30,7 +30,7 @@ public class LombokApiJar extends LombokJarTask {
         File destinationDir = getDestinationDirectory().getAsFile().get();
         getProject().javaexec(apiJar -> {
             apiJar.setClasspath(getLombokClasspath());
-            apiJar.setMain("lombok.launch.Main");
+            apiJar.getMainClass().set("lombok.launch.Main");
             apiJar.args("publicApi", destinationDir.getAbsolutePath());
         });
 

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokRuntimeJar.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokRuntimeJar.java
@@ -40,7 +40,7 @@ public class LombokRuntimeJar extends LombokJarTask {
     public void copy() {
         getProject().javaexec(runtimeJar -> {
             runtimeJar.setClasspath(getLombokClasspath());
-            runtimeJar.setMain("lombok.launch.Main");
+            runtimeJar.getMainClass().set("lombok.launch.Main");
             runtimeJar.args("createRuntime");
 
             if (print.get()) {

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/PostCompile.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/PostCompile.java
@@ -30,7 +30,7 @@ public class PostCompile extends DefaultTask implements LombokTask {
     public void postCompile() {
         getProject().javaexec(postCompile -> {
             postCompile.setClasspath(getLombokClasspath());
-            postCompile.setMain("lombok.launch.Main");
+            postCompile.getMainClass().set("lombok.launch.Main");
             postCompile.args("post-compile");
 
             if (verbose.get()) {


### PR DESCRIPTION
Gradle 7.1 will deprecate `JavaExec.getMain()` and `JavaExec.setMain()` in favor of `mainClass` property: https://github.com/gradle/gradle/pull/16734