### PR TITLE
Fix inconsistent plantuml versioning, use 1.2023.9 everywhere

### DIFF
--- a/plantuml-plugin/build.gradle
+++ b/plantuml-plugin/build.gradle
@@ -4,11 +4,14 @@ apply plugin: "com.gradle.plugin-publish"
 
 description = "Gradle Plugin for PlantUML"
 
+// Note that this version should be kept in sync with src/main/java/io/freefair/gradle/plugins/plantuml/PlantumlPlugin.java
+def plantUmlVersion='1.2023.9'
+
 dependencies {
     //noinspection GradlePackageUpdate
-    compileOnly 'net.sourceforge.plantuml:plantuml:1.2023.9'
+    compileOnly "net.sourceforge.plantuml:plantuml:${plantUmlVersion}"
 
-    testRuntimeOnly 'net.sourceforge.plantuml:plantuml:1.2023.9'
+    testRuntimeOnly "net.sourceforge.plantuml:plantuml:${plantUmlVersion}"
 }
 
 gradlePlugin {

--- a/plantuml-plugin/src/main/java/io/freefair/gradle/plugins/plantuml/PlantumlPlugin.java
+++ b/plantuml-plugin/src/main/java/io/freefair/gradle/plugins/plantuml/PlantumlPlugin.java
@@ -15,7 +15,8 @@ public class PlantumlPlugin implements Plugin<Project> {
         Configuration plantuml = project.getConfigurations().create("plantuml");
 
         plantuml.defaultDependencies(s -> {
-            s.add(project.getDependencies().create("net.sourceforge.plantuml:plantuml:1.2023.8"));
+            // Note that this version should be kept in sync with build.gradle
+            s.add(project.getDependencies().create("net.sourceforge.plantuml:plantuml:1.2023.9"));
         });
 
         project.getTasks().withType(PlantumlTask.class).configureEach(plantumlTask -> {


### PR DESCRIPTION
PlantUml was upgraded to 1.2023.9 in a previous release, but only the dependency used when building the plugin was upgraded. The version used by the plugin at runtime was left untouched.

Given that PlantUml < 1.2023.9 contains CVEs, this is triggering vulnerability warnings in projects using this plugin.

This patch fixes the inconsistent versioning, and adds a few comments in order to make it harder to forget this in the future.