### PR TITLE
Fix Caching Issues in Lombok Plugin

### DIFF
--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokConfig.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokConfig.java
@@ -103,7 +103,7 @@ public abstract class LombokConfig extends DefaultTask implements LombokTask {
     protected List<String> getInputPaths() {
         return getPaths().getFiles()
                 .stream()
-                .map(File::getPath)
+                .map(getProject()::relativePath)
                 .collect(Collectors.toList());
     }
 

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokConfig.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokConfig.java
@@ -110,7 +110,7 @@ public abstract class LombokConfig extends DefaultTask implements LombokTask {
     @InputFiles
     @Optional
     @Nullable
-    @PathSensitive(PathSensitivity.ABSOLUTE)
+    @PathSensitive(PathSensitivity.RELATIVE)
     @SneakyThrows
     protected Set<File> getConfigFiles() {
         if (getPaths().isEmpty()) {

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokConfig.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokConfig.java
@@ -9,6 +9,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Optional;
@@ -42,6 +43,9 @@ public abstract class LombokConfig extends DefaultTask implements LombokTask {
 
     @Inject
     protected abstract FileSystemOperations getFileSystemOperations();
+
+    @Inject
+    protected abstract FileOperations getFileOperations();
 
     @Inject
     protected abstract ExecOperations getExecOperations();
@@ -103,7 +107,7 @@ public abstract class LombokConfig extends DefaultTask implements LombokTask {
     protected List<String> getInputPaths() {
         return getPaths().getFiles()
                 .stream()
-                .map(getProject()::relativePath)
+                .map(getFileOperations()::relativePath)
                 .collect(Collectors.toList());
     }
 

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokConfig.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokConfig.java
@@ -8,6 +8,7 @@ import lombok.SneakyThrows;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileSystemOperations;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.provider.ListProperty;
@@ -45,7 +46,7 @@ public abstract class LombokConfig extends DefaultTask implements LombokTask {
     protected abstract FileSystemOperations getFileSystemOperations();
 
     @Inject
-    protected abstract FileOperations getFileOperations();
+    protected abstract ProjectLayout getProjectLayout();
 
     @Inject
     protected abstract ExecOperations getExecOperations();
@@ -85,7 +86,8 @@ public abstract class LombokConfig extends DefaultTask implements LombokTask {
     /**
      * Paths to java files or directories the configuration is to be printed for.
      */
-    @Internal
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract ConfigurableFileCollection getPaths();
 
     @OutputFile
@@ -101,14 +103,6 @@ public abstract class LombokConfig extends DefaultTask implements LombokTask {
         getNotMentioned().convention(false);
         getOutputs().upToDateWhen(t -> ((LombokConfig) t).getConfigFiles() != null);
         getOutputs().doNotCacheIf("Config Imports were used", t -> ((LombokConfig) t).getConfigFiles() == null);
-    }
-
-    @Input
-    protected List<String> getInputPaths() {
-        return getPaths().getFiles()
-                .stream()
-                .map(getFileOperations()::relativePath)
-                .collect(Collectors.toList());
     }
 
     @InputFiles

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokConfig.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/LombokConfig.java
@@ -8,9 +8,7 @@ import lombok.SneakyThrows;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileSystemOperations;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Optional;
@@ -44,9 +42,6 @@ public abstract class LombokConfig extends DefaultTask implements LombokTask {
 
     @Inject
     protected abstract FileSystemOperations getFileSystemOperations();
-
-    @Inject
-    protected abstract ProjectLayout getProjectLayout();
 
     @Inject
     protected abstract ExecOperations getExecOperations();


### PR DESCRIPTION
### Summary

Makes the following changes to LombokConfig:
1. Updates the configFiles task input to use relative path normalization instead of absolute path normalization
2. Updates the inputPaths task input to return relative paths instead of absolute paths

### Motivation

The usages of absolute paths were causing cache misses in situations that should have been cache hits. For instance, running the task on a CI machine that writes to a remote cache, and then running the same task from a local machine that reads from the remote cache. The absolute path of the two projects is different, which causes a cache miss here, even though the code is identical between them.

### Tests
1. Executed experiment 3 of Gradle's [build validation scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md) against [a test project using a snapshot version of the plugin](https://github.com/tylerbertrand/lombok-plugin-test/tree/main) including the changes in this PR. The test project was built twice, with no code changes between builds, but with the project relocated on disk between builds. With these changes, there are [no input differences between the builds](https://ge.solutions-team.gradle.com/c/dcwgclsdkz7mo/nlmnhgoed5u6y/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure), and in the second build, [the generateEffectiveLombokConfig task came from cache](https://ge.solutions-team.gradle.com/s/nlmnhgoed5u6y/timeline?toggled=WyIzIl0&view=by-type#6l6z5uofelhvo). Executing the same experiment, using [the same test project, but with version 8.6 of the plugin](https://github.com/tylerbertrand/lombok-plugin-test/tree/io-freefair-lombok-8.6), shows [input differences between the two builds](https://ge.solutions-team.gradle.com/c/xpccnkreetz3i/gkeyxb5ujro4y/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure&expanded=WyJzZHo1aGgyb2J1eWt5LWNvbmZpZ2ZpbGVzIl0), and [the generateEffectiveLombokConfig task was executed in the second build](https://ge.solutions-team.gradle.com/s/gkeyxb5ujro4y/timeline?toggled=WyIwIl0&view=by-type#6l6z5uofelhvo).