### PR TITLE
Make AjcForkOptions abstract and instantiate it via ObjectFactory

### DIFF
--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AjcForkOptions.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AjcForkOptions.java
@@ -7,5 +7,5 @@ import org.gradle.api.tasks.compile.BaseForkOptions;
  * @see org.gradle.api.tasks.compile.GroovyForkOptions
  * @see org.gradle.api.tasks.scala.ScalaForkOptions
  */
-public class AjcForkOptions extends BaseForkOptions {
+public abstract class AjcForkOptions extends BaseForkOptions {
 }

--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AspectJCompileOptions.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AspectJCompileOptions.java
@@ -128,7 +128,7 @@ public class AspectJCompileOptions extends AbstractOptions {
      * Options for running the compiler in a child process.
      */
     @Internal
-    private final AjcForkOptions forkOptions = new AjcForkOptions();
+    private final AjcForkOptions forkOptions;
 
     public void forkOptions(Action<AjcForkOptions> action) {
         action.execute(getForkOptions());
@@ -148,5 +148,6 @@ public class AspectJCompileOptions extends AbstractOptions {
         xmlConfigured = objectFactory.fileProperty();
         encoding = objectFactory.property(String.class);
         verbose = objectFactory.property(Boolean.class).convention(false);
+        forkOptions = objectFactory.newInstance(AjcForkOptions.class);
     }
 }


### PR DESCRIPTION
For better compatibility with Gradle 9.

---
In Gradle 9 we plan to replace task/extension properties with Provider API lazy types (Property/Provider/ConfigurableFileCollection). And with that BaseForkOptions will become abstract and have abstract methods, see change:
https://github.com/gradle/gradle/pull/30374/files#diff-c132a92f383d74b12cf1b727c41b2dbc07fffecb7f1ad19c6b1e343ee75cbd30

During smoke tests we found out that AcjForkOptions extends BaseForkOptions. But with Gradle 9 API it then fails with:
```
Execution failed for task ':compileAspectj'.
    > Receiver class io.freefair.gradle.plugins.aspectj.AjcForkOptions 
    does not define or inherit an implementation of the resolved method 
    'abstract org.gradle.api.provider.Property getMemoryInitialSize()' of 
    abstract class org.gradle.api.tasks.compile.BaseForkOptions.
```
A solution to make it compatible with Gradle 9 is to make `AjcForkOptions` abstract and instantiate it via ObjectFactory. This is also ok for previous Gradle versions.