### PR TITLE
switch default lombok version to 1.18.40

### DIFF
--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     javadocClasspath "org.jacoco:org.jacoco.ant:${org.gradle.testing.jacoco.plugins.JacocoPlugin.DEFAULT_JACOCO_VERSION}"
     javadocClasspath "org.apache.maven.plugins:maven-plugin-plugin:3.15.1"
     javadocClasspath 'net.sourceforge.plantuml:plantuml:1.2025.4'
-    javadocClasspath 'org.projectlombok:lombok:1.18.38'
+    javadocClasspath 'org.projectlombok:lombok:1.18.40'
 
     asciidoctorExt "io.spring.asciidoctor:spring-asciidoctor-extensions-block-switch:0.6.3"
 }

--- a/documentation/src/docs/asciidoc/_lombok.adoc
+++ b/documentation/src/docs/asciidoc/_lombok.adoc
@@ -21,14 +21,14 @@ The used Lombok version can be customized using the `lombok` extension:
 .Groovy
 ----
 lombok {
-    version = "1.18.38"
+    version = "1.18.40"
 }
 ----
 [source, groovy, role="secondary"]
 .Kotlin
 ----
 lombok {
-    version = "1.18.38"
+    version = "1.18.40"
 }
 ----
 --

--- a/lombok-plugin/build.gradle
+++ b/lombok-plugin/build.gradle
@@ -8,7 +8,7 @@ description = "Collection of Lombok related Gradle plugins"
 
 dependencies {
     testImplementation project(":test-common")
-    testImplementation 'org.projectlombok:lombok:1.18.38'
+    testImplementation 'org.projectlombok:lombok:1.18.40'
     testImplementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:6.2.0.5505'
 }
 

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokExtension.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokExtension.java
@@ -8,7 +8,7 @@ import org.gradle.api.provider.Property;
  */
 public abstract class LombokExtension {
 
-    public static final String LOMBOK_VERSION = "1.18.38";
+    public static final String LOMBOK_VERSION = "1.18.40";
 
     /**
      * The version of Lombok which will be used.


### PR DESCRIPTION
Lombok 1.18.40 has been released with support for JDK 25: https://projectlombok.org/changelog

It would be great to have this be the default version in the next release of the freefair plugins. 

Please let me know if further requirements need to be met in this PR.