### PR TITLE
Allow plugin-agnostic javadoc link providers

### DIFF
--- a/maven-plugin/src/main/java/io/freefair/gradle/plugins/maven/javadoc/JavadocLinkProvider.java
+++ b/maven-plugin/src/main/java/io/freefair/gradle/plugins/maven/javadoc/JavadocLinkProvider.java
@@ -1,9 +1,16 @@
 package io.freefair.gradle.plugins.maven.javadoc;
 
+import kotlin.jvm.functions.Function3;
+
 import javax.annotation.Nullable;
 
-public interface JavadocLinkProvider {
+public interface JavadocLinkProvider extends Function3<String, String, String, String> {
 
     @Nullable
     String getJavadocLink(String group, String artifact, String version);
+
+    @Override
+    default String invoke(String group, String artifact, String version) {
+        return this.getJavadocLink(group, artifact, version);
+    }
 }


### PR DESCRIPTION
Instead of only allowing JavadocLinkProvider instances via the service loader, an open list property, `linkProviderClassNames`, can be used to add class names of simple classes with no constructor that implement `kotlin.jvm.functions.Function3<String, String, String, String>`.

This fixes two issues:

1. Allows consumers to add different link providers for `resolveJavadocLinks` without needing to manually add additional links to base `Javadoc` tasks. Right now, the task is hard-coded to only use well-known links defined by itself and any JavadocLinkProviders on the classpath *before* the plugin is loaded onto it.
2. Plugins that are applied after the `javadoc-links` plugin are added to the classpath late. When the ServiceLoader attempts to load any classes from these plugins, it will crash with a class loading exception. Allowing type of `Function3<String, String, String, String>`, a global type available at runtime, removes the restriction of needing to implement a specific interface.

This PR, by extension, also eliminates any potential configuration cache issues that could arise from the serialization of `JavadocLinkProvider` objects.