### PR TITLE
Fix configuration cache blocker in LombokExtension

### DIFF
--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokExtension.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokExtension.java
@@ -1,6 +1,9 @@
 package io.freefair.gradle.plugins.lombok;
 
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
+
+import javax.inject.Inject;
 
 /**
  * @author Lars Grefer
@@ -17,9 +20,16 @@ public abstract class LombokExtension {
 
     public abstract Property<Boolean> getDisableConfig();
 
+    @Inject
+    protected abstract ProviderFactory getProviders();
+
     public LombokExtension() {
         getVersion().convention(LOMBOK_VERSION);
 
-        getDisableConfig().convention(System.getProperty("lombok.disableConfig") != null);
+        getDisableConfig().convention(
+            getProviders().systemProperty("lombok.disableConfig")
+                .map(v -> true)
+                .orElse(false)
+        );
     }
 }


### PR DESCRIPTION
Replace System.getProperty() with providers.systemProperty() in LombokExtension to make it configuration cache compatible.

The direct System.getProperty() call during extension construction breaks configuration cache. Using ProviderFactory.systemProperty() properly tracks the system property as a build input and makes it compatible with Gradle 8.x+ configuration cache.