### PR TITLE
Fix eager task realization in LombokPlugin and JavadocLinksPlugin

### DIFF
--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -155,14 +155,14 @@ public class LombokPlugin implements Plugin<Project> {
         TaskProvider<LombokConfig> lombokConfigTask = ConfigUtil.getLombokConfigTask(project, sourceSet);
 
         compileTaskProvider.configure(javaCompile -> {
-            javaCompile.getInputs().file(lombokConfigTask.get().getOutputFile())
+            javaCompile.getInputs().file(lombokConfigTask.flatMap(LombokConfig::getOutputFile))
                     .withPropertyName("lombok.config")
                     .withPathSensitivity(PathSensitivity.NONE)
                     .optional();
         });
 
         delombokTaskProvider.configure(delombok -> {
-            delombok.getInputs().file(lombokConfigTask.get().getOutputFile())
+            delombok.getInputs().file(lombokConfigTask.flatMap(LombokConfig::getOutputFile))
                     .withPropertyName("lombok.config")
                     .withPathSensitivity(PathSensitivity.NONE)
                     .optional();

--- a/maven-plugin/src/main/java/io/freefair/gradle/plugins/maven/javadoc/JavadocLinksPlugin.java
+++ b/maven-plugin/src/main/java/io/freefair/gradle/plugins/maven/javadoc/JavadocLinksPlugin.java
@@ -52,7 +52,7 @@ public class JavadocLinksPlugin implements Plugin<Project> {
         TaskProvider<ResolveJavadocLinks> resolveJavadocLinks = project.getTasks().register("resolveJavadocLinks", ResolveJavadocLinks.class);
 
         resolveJavadocLinks.configure(rjd -> {
-            rjd.getJavadocTool().convention(javadocTaskProvider.get().getJavadocTool());
+            rjd.getJavadocTool().convention(javadocTaskProvider.flatMap(Javadoc::getJavadocTool));
             rjd.setClasspath(classpath);
         });
 
@@ -66,7 +66,7 @@ public class JavadocLinksPlugin implements Plugin<Project> {
 
             if (options instanceof StandardJavadocDocletOptions) {
                 StandardJavadocDocletOptions standardOptions = (StandardJavadocDocletOptions) options;
-                standardOptions.linksFile(resolveJavadocLinks.get().getOutputFile().get().getAsFile());
+                standardOptions.linksFile(resolveJavadocLinks.flatMap(ResolveJavadocLinks::getOutputFile).map(f -> f.getAsFile()).get());
             }
         });
 


### PR DESCRIPTION
Replace .get() calls on TaskProvider with flatMap() to avoid eager task realization during configuration phase.

Changes:
- LombokPlugin: Use flatMap(LombokConfig::getOutputFile) instead of get().getOutputFile() when wiring task inputs
- JavadocLinksPlugin: Use flatMap(Javadoc::getJavadocTool) instead of get().getJavadocTool() when setting convention
- JavadocLinksPlugin: Chain providers properly with flatMap() before calling get() only when necessary inside lazy configure block

This enables proper task configuration avoidance and improves build performance by not configuring tasks until they are actually needed.