### PR TITLE
Replace getByName() with named() in AspectJ plugins

### DIFF
--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AspectJPlugin.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AspectJPlugin.java
@@ -61,11 +61,11 @@ public class AspectJPlugin implements Plugin<Project> {
     }
 
     private void configureJavaPlugin(Project project) {
-        SourceSet main = javaExtension.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
-        SourceSet test = javaExtension.getSourceSets().getByName(SourceSet.TEST_SOURCE_SET_NAME);
+        SourceSet main = javaExtension.getSourceSets().named(SourceSet.MAIN_SOURCE_SET_NAME).get();
+        SourceSet test = javaExtension.getSourceSets().named(SourceSet.TEST_SOURCE_SET_NAME).get();
 
-        Configuration aspectpath = project.getConfigurations().getByName(WeavingSourceSet.getAspectConfigurationName(main));
-        Configuration testAspectpath = project.getConfigurations().getByName(WeavingSourceSet.getAspectConfigurationName(test));
+        Configuration aspectpath = project.getConfigurations().named(WeavingSourceSet.getAspectConfigurationName(main)).get();
+        Configuration testAspectpath = project.getConfigurations().named(WeavingSourceSet.getAspectConfigurationName(test)).get();
 
         testAspectpath.extendsFrom(aspectpath);
 
@@ -104,9 +104,9 @@ public class AspectJPlugin implements Plugin<Project> {
         Configuration inpath = project.getConfigurations().create(WeavingSourceSet.getInpathConfigurationName(sourceSet));
         WeavingSourceSet.getInPath(sourceSet).from(inpath);
 
-        project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName()).extendsFrom(aspect);
+        project.getConfigurations().named(sourceSet.getImplementationConfigurationName()).get().extendsFrom(aspect);
 
-        project.getConfigurations().getByName(sourceSet.getCompileOnlyConfigurationName()).extendsFrom(inpath);
+        project.getConfigurations().named(sourceSet.getCompileOnlyConfigurationName()).get().extendsFrom(inpath);
 
         final TaskProvider<AspectjCompile> compileTask = project.getTasks().register(sourceSet.getCompileTaskName("aspectj"), AspectjCompile.class, compile -> {
             JvmPluginsHelper.compileAgainstJavaOutputs(compile, sourceSet, project.getObjects());

--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AspectJPostCompileWeavingPlugin.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AspectJPostCompileWeavingPlugin.java
@@ -70,8 +70,8 @@ public class AspectJPostCompileWeavingPlugin implements Plugin<Project> {
         Configuration inpath = project.getConfigurations().create(WeavingSourceSet.getInpathConfigurationName(sourceSet));
         WeavingSourceSet.getInPath(sourceSet).from(inpath);
 
-        project.getConfigurations().getByName(sourceSet.getImplementationConfigurationName()).extendsFrom(aspectpath);
-        project.getConfigurations().getByName(sourceSet.getCompileOnlyConfigurationName()).extendsFrom(inpath);
+        project.getConfigurations().named(sourceSet.getImplementationConfigurationName()).get().extendsFrom(aspectpath);
+        project.getConfigurations().named(sourceSet.getCompileOnlyConfigurationName()).get().extendsFrom(inpath);
     }
 
     private void configurePlugin(String language) {
@@ -79,8 +79,8 @@ public class AspectJPostCompileWeavingPlugin implements Plugin<Project> {
             FileCollection aspectpath = WeavingSourceSet.getAspectPath(sourceSet);
             FileCollection inpath = WeavingSourceSet.getInPath(sourceSet);
 
-            Configuration runtimeClasspath = project.getConfigurations().getByName(sourceSet.getRuntimeClasspathConfigurationName());
-            Configuration compileClasspath = project.getConfigurations().getByName(sourceSet.getCompileClasspathConfigurationName());
+            Configuration runtimeClasspath = project.getConfigurations().named(sourceSet.getRuntimeClasspathConfigurationName()).get();
+            Configuration compileClasspath = project.getConfigurations().named(sourceSet.getCompileClasspathConfigurationName()).get();
             ConfigurableFileCollection searchPath = project.files(runtimeClasspath, compileClasspath);
             FileCollection aspectjClasspath = aspectjBasePlugin.getAspectjRuntime().inferAspectjClasspath(searchPath);
 


### PR DESCRIPTION
Replace eager getByName() calls with lazy named() for better configuration performance and consistency with Gradle best practices.

Changes in AspectJPlugin.java:
- Use named() for SourceSets access (lines 64, 65)
- Use named() for Configurations access (lines 67, 68, 107, 109)

Changes in AspectJPostCompileWeavingPlugin.java:
- Use named() for Configurations access (lines 73, 74, 82, 83)

Note: Extension.getByName() calls in WeavingSourceSet.java and AspectjSourceSet.java are kept as-is since extensions don't have a named() method.

This change improves configuration performance by using lazy providers consistently with the named() API, which is the recommended approach for accessing named domain objects in Gradle.