### PR TITLE
Add baseline tests for plugins with zero test coverage.

### DIFF
--- a/embedded-sass-plugin/src/test/java/io/freefair/gradle/plugins/sass/SassBasePluginTest.java
+++ b/embedded-sass-plugin/src/test/java/io/freefair/gradle/plugins/sass/SassBasePluginTest.java
@@ -1,0 +1,37 @@
+package io.freefair.gradle.plugins.sass;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Baseline tests for SassBasePlugin.
+ */
+public class SassBasePluginTest {
+
+    private Project project;
+
+    @BeforeEach
+    public void setUp() {
+        project = ProjectBuilder.builder().build();
+    }
+
+    @Test
+    public void pluginApplies() {
+        project.getPlugins().apply(SassBasePlugin.class);
+
+        assertThat(project.getPlugins().hasPlugin(SassBasePlugin.class)).isTrue();
+    }
+
+    @Test
+    public void extensionIsRegistered() {
+        project.getPlugins().apply(SassBasePlugin.class);
+
+        SassExtension extension = project.getExtensions().getByType(SassExtension.class);
+
+        assertThat(extension).isNotNull();
+    }
+}

--- a/gwt-plugin/src/test/java/io/freefair/gradle/plugins/gwt/GwtBasePluginTest.java
+++ b/gwt-plugin/src/test/java/io/freefair/gradle/plugins/gwt/GwtBasePluginTest.java
@@ -1,0 +1,60 @@
+package io.freefair.gradle.plugins.gwt;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Baseline tests for GwtBasePlugin.
+ */
+public class GwtBasePluginTest {
+
+    private Project project;
+
+    @BeforeEach
+    public void setUp() {
+        project = ProjectBuilder.builder().build();
+    }
+
+    @Test
+    public void pluginApplies() {
+        project.getPlugins().apply(GwtBasePlugin.class);
+
+        assertThat(project.getPlugins().hasPlugin(GwtBasePlugin.class)).isTrue();
+    }
+
+    @Test
+    public void extensionIsRegistered() {
+        project.getPlugins().apply(GwtBasePlugin.class);
+
+        GwtExtension extension = project.getExtensions().getByType(GwtExtension.class);
+
+        assertThat(extension).isNotNull();
+    }
+
+    @Test
+    public void configurationsAreCreated() {
+        project.getPlugins().apply(GwtBasePlugin.class);
+
+        Configuration gwtDev = project.getConfigurations().findByName("gwtDev");
+        Configuration gwtClasspath = project.getConfigurations().findByName("gwtClasspath");
+        Configuration gwtSources = project.getConfigurations().findByName("gwtSources");
+
+        assertThat(gwtDev).isNotNull();
+        assertThat(gwtClasspath).isNotNull();
+        assertThat(gwtSources).isNotNull();
+    }
+
+    @Test
+    public void tasksAreRegistered() {
+        project.getPlugins().apply(GwtBasePlugin.class);
+
+        assertThat(project.getTasks().findByName("gwtCompile")).isNotNull();
+        assertThat(project.getTasks().findByName("gwtDevMode")).isNotNull();
+        assertThat(project.getTasks().findByName("gwtCodeServer")).isNotNull();
+    }
+}

--- a/jacoco-plugin/src/test/java/io/freefair/gradle/plugins/jacoco/AggregateJacocoReportPluginTest.java
+++ b/jacoco-plugin/src/test/java/io/freefair/gradle/plugins/jacoco/AggregateJacocoReportPluginTest.java
@@ -1,0 +1,58 @@
+package io.freefair.gradle.plugins.jacoco;
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.gradle.testing.jacoco.plugins.JacocoPlugin;
+import org.gradle.testing.jacoco.tasks.JacocoReport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Baseline tests for AggregateJacocoReportPlugin.
+ */
+public class AggregateJacocoReportPluginTest {
+
+    private Project rootProject;
+
+    @BeforeEach
+    public void setUp() {
+        rootProject = ProjectBuilder.builder().build();
+    }
+
+    @Test
+    public void pluginApplies() {
+        rootProject.getPlugins().apply(AggregateJacocoReportPlugin.class);
+
+        assertThat(rootProject.getPlugins().hasPlugin(AggregateJacocoReportPlugin.class)).isTrue();
+        assertThat(rootProject.getPlugins().hasPlugin(JacocoPlugin.class)).isTrue();
+    }
+
+    @Test
+    public void aggregateTaskIsRegistered() {
+        rootProject.getPlugins().apply(AggregateJacocoReportPlugin.class);
+
+        assertThat(rootProject.getTasks().findByName("aggregateJacocoReport")).isNotNull();
+        assertThat(rootProject.getTasks().findByName("aggregateJacocoReport"))
+                .isInstanceOf(JacocoReport.class);
+    }
+
+    @Test
+    public void aggregateTaskWithSubprojects() {
+        // Create subproject
+        Project subproject = ProjectBuilder.builder()
+                .withName("subproject")
+                .withParent(rootProject)
+                .build();
+
+        rootProject.getPlugins().apply(AggregateJacocoReportPlugin.class);
+        subproject.getPlugins().apply(JavaPlugin.class);
+
+        JacocoReport aggregateTask = (JacocoReport) rootProject.getTasks().getByName("aggregateJacocoReport");
+
+        assertThat(aggregateTask).isNotNull();
+        assertThat(aggregateTask.getGroup()).isEqualTo("verification");
+    }
+}

--- a/okhttp-plugin/src/test/java/io/freefair/gradle/plugins/okhttp/OkHttpPluginTest.java
+++ b/okhttp-plugin/src/test/java/io/freefair/gradle/plugins/okhttp/OkHttpPluginTest.java
@@ -1,0 +1,58 @@
+package io.freefair.gradle.plugins.okhttp;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Baseline tests for OkHttpPlugin.
+ */
+public class OkHttpPluginTest {
+
+    private Project project;
+
+    @BeforeEach
+    public void setUp() {
+        project = ProjectBuilder.builder().build();
+    }
+
+    @Test
+    public void pluginApplies() {
+        project.getPlugins().apply(OkHttpPlugin.class);
+
+        assertThat(project.getPlugins().hasPlugin(OkHttpPlugin.class)).isTrue();
+    }
+
+    @Test
+    public void extensionIsRegistered() {
+        project.getPlugins().apply(OkHttpPlugin.class);
+
+        OkHttpExtension extension = project.getExtensions().getByType(OkHttpExtension.class);
+
+        assertThat(extension).isNotNull();
+        assertThat(extension.getCacheSize().get()).isEqualTo(10 * 1024 * 1024);
+    }
+
+    @Test
+    public void extensionCanBeConfigured() {
+        project.getPlugins().apply(OkHttpPlugin.class);
+
+        OkHttpExtension extension = project.getExtensions().getByType(OkHttpExtension.class);
+        extension.getCacheSize().set(5 * 1024 * 1024);
+
+        assertThat(extension.getCacheSize().get()).isEqualTo(5 * 1024 * 1024);
+    }
+
+    @Test
+    public void offlineModeEnablesForceCache() {
+        project.getGradle().getStartParameter().setOffline(true);
+        project.getPlugins().apply(OkHttpPlugin.class);
+
+        OkHttpExtension extension = project.getExtensions().getByType(OkHttpExtension.class);
+
+        assertThat(extension.getForceCache().get()).isTrue();
+    }
+}

--- a/quicktype-plugin/src/test/kotlin/io/freefair/gradle/plugins/quicktype/QuicktypePluginTest.kt
+++ b/quicktype-plugin/src/test/kotlin/io/freefair/gradle/plugins/quicktype/QuicktypePluginTest.kt
@@ -1,0 +1,28 @@
+package io.freefair.gradle.plugins.quicktype
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Baseline tests for QuicktypePlugin.
+ */
+class QuicktypePluginTest {
+
+    private lateinit var project: org.gradle.api.Project
+
+    @BeforeEach
+    fun setUp() {
+        project = ProjectBuilder.builder().build()
+    }
+
+    @Test
+    fun pluginApplies() {
+        project.plugins.apply(QuicktypePlugin::class.java)
+
+        assertThat(project.plugins.hasPlugin(QuicktypePlugin::class.java)).isTrue()
+        assertThat(project.plugins.hasPlugin(JavaPlugin::class.java)).isTrue()
+    }
+}


### PR DESCRIPTION
Added basic unit tests for OkHttpPlugin, AggregateJacocoReportPlugin, GwtBasePlugin, SassBasePlugin, and QuicktypePlugin to establish baseline test coverage and verify plugin application and extension registration.