### PR TITLE
Replace upToDateWhen with @UntrackedTask annotation in GWT tasks.

### DIFF
--- a/gwt-plugin/src/main/java/io/freefair/gradle/plugins/gwt/tasks/GwtCodeServerTask.java
+++ b/gwt-plugin/src/main/java/io/freefair/gradle/plugins/gwt/tasks/GwtCodeServerTask.java
@@ -1,6 +1,7 @@
 package io.freefair.gradle.plugins.gwt.tasks;
 
 import io.freefair.gradle.plugins.gwt.GwtCodeServerOptions;
+import org.gradle.api.tasks.UntrackedTask;
 import org.gradle.process.CommandLineArgumentProvider;
 
 import java.util.ArrayList;
@@ -9,10 +10,10 @@ import java.util.List;
 /**
  * @author Lars Grefer
  */
+@UntrackedTask(because = "Runs an interactive development code server that does not produce cacheable outputs")
 public abstract class GwtCodeServerTask extends AbstractGwtTask implements GwtCodeServerOptions {
 
     public GwtCodeServerTask() {
-        this.getOutputs().upToDateWhen(task -> false);
         getMainClass().set("com.google.gwt.dev.codeserver.CodeServer");
 
         getArgumentProviders().add(new ArgProvider());

--- a/gwt-plugin/src/main/java/io/freefair/gradle/plugins/gwt/tasks/GwtDevModeTask.java
+++ b/gwt-plugin/src/main/java/io/freefair/gradle/plugins/gwt/tasks/GwtDevModeTask.java
@@ -1,6 +1,7 @@
 package io.freefair.gradle.plugins.gwt.tasks;
 
 import io.freefair.gradle.plugins.gwt.GwtDevModeOptions;
+import org.gradle.api.tasks.UntrackedTask;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -8,11 +9,10 @@ import java.util.List;
 /**
  * @author Lars Grefer
  */
+@UntrackedTask(because = "Runs an interactive development server that does not produce cacheable outputs")
 public abstract class GwtDevModeTask extends AbstractGwtTask implements GwtDevModeOptions {
 
     public GwtDevModeTask() {
-        this.getOutputs().upToDateWhen(task -> false);
-
         getMainClass().convention("com.google.gwt.dev.DevMode");
 
         getArgumentProviders().add(new ArgumentProvider());


### PR DESCRIPTION
Modernize GwtCodeServerTask and GwtDevModeTask to use the declarative @UntrackedTask annotation instead of the imperative upToDateWhen(task -> false). This follows Gradle best practices and clearly documents why these interactive development server tasks should not participate in up-to-date checking.