### PR TITLE
Add @CacheableTask annotations to deterministic transformation tasks.

### DIFF
--- a/code-generator-plugin/src/main/java/io/freefair/gradle/plugin/codegenerator/GenerateCodeTask.java
+++ b/code-generator-plugin/src/main/java/io/freefair/gradle/plugin/codegenerator/GenerateCodeTask.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 @Getter
 @Setter
+@CacheableTask
 public abstract class GenerateCodeTask extends DefaultTask {
 
     @Inject
@@ -39,6 +40,7 @@ public abstract class GenerateCodeTask extends DefaultTask {
 
     @InputDirectory
     @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract DirectoryProperty getInputDir();
 
     @OutputDirectory

--- a/compress-plugin/src/main/java/io/freefair/gradle/plugins/compress/tasks/CompressorTask.java
+++ b/compress-plugin/src/main/java/io/freefair/gradle/plugins/compress/tasks/CompressorTask.java
@@ -10,6 +10,7 @@ import org.gradle.workers.WorkerExecutor;
 import javax.inject.Inject;
 import java.io.File;
 
+@CacheableTask
 public abstract class CompressorTask<P extends CompressorWorkParameters> extends SourceTask {
 
     @Inject

--- a/maven-plugin-plugin/src/main/java/io/freefair/gradle/plugins/maven/plugin/DescriptorGeneratorTask.java
+++ b/maven-plugin-plugin/src/main/java/io/freefair/gradle/plugins/maven/plugin/DescriptorGeneratorTask.java
@@ -46,18 +46,22 @@ import java.util.stream.Collectors;
  * @see DescriptorGeneratorMojo
  */
 @Getter
+@CacheableTask
 public abstract class DescriptorGeneratorTask extends AbstractGeneratorTask {
 
     @Inject
     protected abstract ProjectLayout getProjectLayout();
 
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract ConfigurableFileCollection getSourceDirectories();
 
     @InputFiles
+    @Classpath
     public abstract ConfigurableFileCollection getClassesDirectories();
 
     @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract RegularFileProperty getPomFile();
 
     @OutputDirectory

--- a/plantuml-plugin/src/main/java/io/freefair/gradle/plugins/plantuml/PlantumlTask.java
+++ b/plantuml-plugin/src/main/java/io/freefair/gradle/plugins/plantuml/PlantumlTask.java
@@ -16,6 +16,7 @@ import java.io.File;
 /**
  * @author Lars Grefer
  */
+@CacheableTask
 public abstract class PlantumlTask extends SourceTask {
 
     @Inject


### PR DESCRIPTION
Mark PlantumlTask, GenerateCodeTask, CompressorTask, and DescriptorGeneratorTask as cacheable to improve build performance. These tasks produce deterministic outputs based on their inputs and benefit from Gradle's build cache.

Also add required path normalization annotations (@PathSensitive, @Classpath) to ensure proper cache key computation across different machines and directories.