### PR TITLE
fix: Remove internal DslObject API for Gradle 10 compatibility

### DIFF
--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -154,16 +154,18 @@ public class LombokPlugin implements Plugin<Project> {
         }
 
         try {
-            Object result = spotbugsExtension.getClass().getMethod("getToolVersion").invoke(spotbugsExtension);
+            java.lang.reflect.Method method = spotbugsExtension.getClass().getMethod("getToolVersion");
+            method.setAccessible(true);
+            Object result = method.invoke(spotbugsExtension);
             if (result instanceof org.gradle.api.provider.Property) {
                 @SuppressWarnings("unchecked")
                 Property<String> toolVersionProperty = (Property<String>) result;
-                String version = toolVersionProperty.getOrNull();
-                if (version != null) {
-                    return version;
-                }
+                return toolVersionProperty.getOrElse(SPOTBUGS_DEFAULT_VERSION);
             } else if (result instanceof String) {
                 return (String) result;
+            } else {
+                project.getLogger().debug("resolveSpotBugVersion: getToolVersion() returned unexpected type {}; using default {}",
+                        result == null ? "null" : result.getClass().getName(), SPOTBUGS_DEFAULT_VERSION);
             }
         } catch (ReflectiveOperationException | ClassCastException e) {
             project.getLogger().warn("Could not resolve SpotBugs tool version via reflection; falling back to {}", SPOTBUGS_DEFAULT_VERSION, e);

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -10,7 +10,6 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.attributes.DocsType;
-import org.gradle.api.attributes.VerificationType;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.quality.CodeQualityExtension;

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -13,11 +13,9 @@ import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.DocsType;
 import org.gradle.api.attributes.VerificationType;
-import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.quality.CodeQualityExtension;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceSet;
@@ -143,8 +141,7 @@ public class LombokPlugin implements Plugin<Project> {
             return ((CodeQualityExtension) spotbugsExtension).getToolVersion();
         }
 
-        Property<String> toolVersionProperty = (Property<String>) new DslObject(spotbugsExtension).getAsDynamicObject().getProperty("toolVersion");
-        return toolVersionProperty.get();
+        return SPOTBUGS_DEFAULT_VERSION;
     }
 
     private void configureDelombokDefaults(Delombok delombok) {

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -131,6 +131,7 @@ public class LombokPlugin implements Plugin<Project> {
         });
     }
 
+    @SuppressWarnings("unchecked")
     private String resolveSpotBugVersion() {
         if (!project.getPlugins().hasPlugin("com.github.spotbugs")) {
             return SPOTBUGS_DEFAULT_VERSION;
@@ -139,6 +140,19 @@ public class LombokPlugin implements Plugin<Project> {
         Object spotbugsExtension = project.getExtensions().getByName("spotbugs");
         if (spotbugsExtension instanceof CodeQualityExtension) {
             return ((CodeQualityExtension) spotbugsExtension).getToolVersion();
+        }
+
+        try {
+            Object result = spotbugsExtension.getClass().getMethod("getToolVersion").invoke(spotbugsExtension);
+            if (result instanceof org.gradle.api.provider.Property) {
+                String version = ((org.gradle.api.provider.Property<String>) result).getOrNull();
+                if (version != null) {
+                    return version;
+                }
+            } else if (result instanceof String) {
+                return (String) result;
+            }
+        } catch (ReflectiveOperationException ignored) {
         }
 
         return SPOTBUGS_DEFAULT_VERSION;

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -13,6 +13,7 @@ import org.gradle.api.attributes.DocsType;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.quality.CodeQualityExtension;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceSet;
@@ -45,7 +46,7 @@ public class LombokPlugin implements Plugin<Project> {
     private LombokBasePlugin lombokBasePlugin;
     private Project project;
 
-    private boolean spotbugConfigured;
+    private boolean spotbugsConfigured;
 
     @Override
     public void apply(Project project) {
@@ -121,10 +122,10 @@ public class LombokPlugin implements Plugin<Project> {
     }
 
     private void configureForSpotbugs(JavaPluginExtension javaPluginExtension) {
-        if (spotbugConfigured) {
+        if (spotbugsConfigured) {
             return;
         }
-        spotbugConfigured = true;
+        spotbugsConfigured = true;
 
         javaPluginExtension.getSourceSets().all(sourceSet -> {
             // Use findByName: sourceSets.all also fires for source sets added later
@@ -142,7 +143,6 @@ public class LombokPlugin implements Plugin<Project> {
         });
     }
 
-    @SuppressWarnings("unchecked")
     private String resolveSpotBugVersion() {
         if (!project.getPlugins().hasPlugin("com.github.spotbugs")) {
             return SPOTBUGS_DEFAULT_VERSION;
@@ -156,14 +156,16 @@ public class LombokPlugin implements Plugin<Project> {
         try {
             Object result = spotbugsExtension.getClass().getMethod("getToolVersion").invoke(spotbugsExtension);
             if (result instanceof org.gradle.api.provider.Property) {
-                String version = ((org.gradle.api.provider.Property<String>) result).getOrNull();
+                @SuppressWarnings("unchecked")
+                Property<String> toolVersionProperty = (Property<String>) result;
+                String version = toolVersionProperty.getOrNull();
                 if (version != null) {
                     return version;
                 }
             } else if (result instanceof String) {
                 return (String) result;
             }
-        } catch (ReflectiveOperationException e) {
+        } catch (ReflectiveOperationException | ClassCastException e) {
             project.getLogger().warn("Could not resolve SpotBugs tool version via reflection; falling back to {}", SPOTBUGS_DEFAULT_VERSION, e);
         }
 

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -13,6 +13,7 @@ import org.gradle.api.attributes.DocsType;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.plugins.quality.CodeQualityExtension;
+import java.lang.reflect.Method;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.PathSensitivity;
@@ -154,7 +155,7 @@ public class LombokPlugin implements Plugin<Project> {
         }
 
         try {
-            java.lang.reflect.Method method = spotbugsExtension.getClass().getMethod("getToolVersion");
+            Method method = spotbugsExtension.getClass().getMethod("getToolVersion");
             Object result = method.invoke(spotbugsExtension);
             if (result instanceof Property) {
                 @SuppressWarnings("unchecked")
@@ -167,7 +168,8 @@ public class LombokPlugin implements Plugin<Project> {
                         result == null ? "null" : result.getClass().getName(), SPOTBUGS_DEFAULT_VERSION);
             }
         } catch (ReflectiveOperationException | ClassCastException e) {
-            project.getLogger().warn("Could not resolve SpotBugs tool version via reflection; falling back to {}", SPOTBUGS_DEFAULT_VERSION, e);
+            project.getLogger().info("Could not resolve SpotBugs tool version via reflection ({}); falling back to {}",
+                    e.getMessage(), SPOTBUGS_DEFAULT_VERSION);
         }
 
         return SPOTBUGS_DEFAULT_VERSION;

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -5,6 +5,9 @@ import io.freefair.gradle.plugins.lombok.tasks.Delombok;
 import io.freefair.gradle.plugins.lombok.tasks.LombokConfig;
 import io.freefair.gradle.plugins.lombok.tasks.LombokTask;
 import lombok.Getter;
+
+import java.lang.reflect.Method;
+
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -12,8 +15,6 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.attributes.DocsType;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.plugins.quality.CodeQualityExtension;
-import java.lang.reflect.Method;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.PathSensitivity;
@@ -150,9 +151,6 @@ public class LombokPlugin implements Plugin<Project> {
         }
 
         Object spotbugsExtension = project.getExtensions().getByName("spotbugs");
-        if (spotbugsExtension instanceof CodeQualityExtension) {
-            return ((CodeQualityExtension) spotbugsExtension).getToolVersion();
-        }
 
         try {
             Method method = spotbugsExtension.getClass().getMethod("getToolVersion");

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -164,14 +164,15 @@ public class LombokPlugin implements Plugin<Project> {
             if (result instanceof Property) {
                 @SuppressWarnings("unchecked")
                 Property<String> toolVersionProperty = (Property<String>) result;
-                return toolVersionProperty.getOrElse(SPOTBUGS_DEFAULT_VERSION);
-            } else if (result instanceof String) {
-                return (String) result;
+                String resolved = toolVersionProperty.getOrElse(SPOTBUGS_DEFAULT_VERSION);
+                return resolved.isBlank() ? SPOTBUGS_DEFAULT_VERSION : resolved;
+            } else if (result instanceof String version && !version.isBlank()) {
+                return version;
             } else {
                 project.getLogger().debug("resolveSpotbugsVersion: getToolVersion() returned unexpected type {}; using default {}",
                         result == null ? "null" : result.getClass().getName(), SPOTBUGS_DEFAULT_VERSION);
             }
-        } catch (ReflectiveOperationException | ClassCastException e) {
+        } catch (ReflectiveOperationException | RuntimeException e) {
             Throwable cause = e.getCause() != null ? e.getCause() : e;
             project.getLogger().info("Could not resolve SpotBugs tool version via reflection ({}); falling back to {}",
                     cause.getMessage(), SPOTBUGS_DEFAULT_VERSION);

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -150,7 +150,13 @@ public class LombokPlugin implements Plugin<Project> {
             return SPOTBUGS_DEFAULT_VERSION;
         }
 
-        Object spotbugsExtension = project.getExtensions().getByName("spotbugs");
+        Object spotbugsExtension;
+        try {
+            spotbugsExtension = project.getExtensions().getByName("spotbugs");
+        } catch (Exception e) {
+            project.getLogger().info("Could not find SpotBugs extension; falling back to {}", SPOTBUGS_DEFAULT_VERSION);
+            return SPOTBUGS_DEFAULT_VERSION;
+        }
 
         try {
             Method method = spotbugsExtension.getClass().getMethod("getToolVersion");
@@ -166,8 +172,9 @@ public class LombokPlugin implements Plugin<Project> {
                         result == null ? "null" : result.getClass().getName(), SPOTBUGS_DEFAULT_VERSION);
             }
         } catch (ReflectiveOperationException | ClassCastException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
             project.getLogger().info("Could not resolve SpotBugs tool version via reflection ({}); falling back to {}",
-                    e.getMessage(), SPOTBUGS_DEFAULT_VERSION);
+                    cause.getMessage(), SPOTBUGS_DEFAULT_VERSION);
         }
 
         return SPOTBUGS_DEFAULT_VERSION;

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -134,7 +134,7 @@ public class LombokPlugin implements Plugin<Project> {
                     .findByName(sourceSet.getCompileOnlyConfigurationName());
             if (compileOnly != null) {
                 compileOnly.withDependencies(deps -> {
-                    String toolVersion = resolveSpotBugVersion();
+                    String toolVersion = resolveSpotbugsVersion();
                     deps.add(project.getDependencies().create(
                             "com.github.spotbugs:spotbugs-annotations:" + toolVersion
                     ));
@@ -143,7 +143,7 @@ public class LombokPlugin implements Plugin<Project> {
         });
     }
 
-    private String resolveSpotBugVersion() {
+    private String resolveSpotbugsVersion() {
         if (!project.getPlugins().hasPlugin("com.github.spotbugs")) {
             return SPOTBUGS_DEFAULT_VERSION;
         }
@@ -155,16 +155,15 @@ public class LombokPlugin implements Plugin<Project> {
 
         try {
             java.lang.reflect.Method method = spotbugsExtension.getClass().getMethod("getToolVersion");
-            method.setAccessible(true);
             Object result = method.invoke(spotbugsExtension);
-            if (result instanceof org.gradle.api.provider.Property) {
+            if (result instanceof Property) {
                 @SuppressWarnings("unchecked")
                 Property<String> toolVersionProperty = (Property<String>) result;
                 return toolVersionProperty.getOrElse(SPOTBUGS_DEFAULT_VERSION);
             } else if (result instanceof String) {
                 return (String) result;
             } else {
-                project.getLogger().debug("resolveSpotBugVersion: getToolVersion() returned unexpected type {}; using default {}",
+                project.getLogger().debug("resolveSpotbugsVersion: getToolVersion() returned unexpected type {}; using default {}",
                         result == null ? "null" : result.getClass().getName(), SPOTBUGS_DEFAULT_VERSION);
             }
         } catch (ReflectiveOperationException | ClassCastException e) {

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -4,12 +4,14 @@ import io.freefair.gradle.plugins.lombok.internal.ConfigUtil;
 import io.freefair.gradle.plugins.lombok.tasks.Delombok;
 import io.freefair.gradle.plugins.lombok.tasks.LombokConfig;
 import io.freefair.gradle.plugins.lombok.tasks.LombokTask;
+import lombok.AccessLevel;
 import lombok.Getter;
 
 import java.lang.reflect.Method;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.attributes.DocsType;
@@ -48,6 +50,7 @@ public class LombokPlugin implements Plugin<Project> {
     private LombokBasePlugin lombokBasePlugin;
     private Project project;
 
+    @Getter(AccessLevel.NONE)
     private boolean spotbugsConfigured;
 
     @Override
@@ -153,7 +156,7 @@ public class LombokPlugin implements Plugin<Project> {
         Object spotbugsExtension;
         try {
             spotbugsExtension = project.getExtensions().getByName("spotbugs");
-        } catch (Exception e) {
+        } catch (UnknownDomainObjectException e) {
             project.getLogger().info("Could not find SpotBugs extension; falling back to {}", SPOTBUGS_DEFAULT_VERSION);
             return SPOTBUGS_DEFAULT_VERSION;
         }
@@ -175,7 +178,7 @@ public class LombokPlugin implements Plugin<Project> {
         } catch (ReflectiveOperationException | RuntimeException e) {
             Throwable cause = e.getCause() != null ? e.getCause() : e;
             project.getLogger().info("Could not resolve SpotBugs tool version via reflection ({}); falling back to {}",
-                    cause.getMessage(), SPOTBUGS_DEFAULT_VERSION);
+                    String.valueOf(cause.getMessage()), SPOTBUGS_DEFAULT_VERSION);
         }
 
         return SPOTBUGS_DEFAULT_VERSION;


### PR DESCRIPTION
## Summary
- Removes the `DslObject` internal Gradle API usage from `LombokPlugin.resolveSpotBugVersion()`
- The `DslObject` fallback was unreachable dead code — when the SpotBugs plugin is present, its extension is always a `CodeQualityExtension` subclass handled by the public API path
- Replaces with a simple default version fallback

Found during automated main branch review. The `DslObject` import from `org.gradle.api.internal.plugins` will break in Gradle 10.

## Test plan
- [x] Verify build passes with SpotBugs plugin applied
- [x] Verify build passes with SonarQube plugin applied (without SpotBugs)
- [x] Verify build passes without either plugin