### PR TITLE
Improve documentation with Getting Started, Quick Reference, and llms.txt

### DIFF
--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -40,6 +40,13 @@ tasks.named("javadoc", Javadoc) {
     failOnError = true
 }
 
+tasks.register("copyLlmsTxt", Copy) {
+    from "src/docs/asciidoc/llms.txt"
+    into asciidoctor.outputDir
+}
+
+asciidoctor.finalizedBy("copyLlmsTxt")
+
 tasks.register("docsZip", Zip) {
     group = 'build'
     archiveClassifier = 'docs'

--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -43,14 +43,13 @@ tasks.named("javadoc", Javadoc) {
 tasks.register("copyLlmsTxt", Copy) {
     from "src/docs/asciidoc/llms.txt"
     into asciidoctor.outputDir
+    dependsOn asciidoctor
 }
-
-asciidoctor.finalizedBy("copyLlmsTxt")
 
 tasks.register("docsZip", Zip) {
     group = 'build'
     archiveClassifier = 'docs'
-    dependsOn asciidoctor
+    dependsOn tasks.named("copyLlmsTxt")
 
     into("api") {
         from javadoc

--- a/documentation/src/docs/asciidoc/_aspectj.adoc
+++ b/documentation/src/docs/asciidoc/_aspectj.adoc
@@ -13,14 +13,119 @@ ____
 - clean modularization of crosscutting concerns, such as error checking and handling, synchronization, context-sensitive behavior, performance optimizations, monitoring and logging, debugging support, and multi-object protocols
 ____
 
+== Getting Started
+
+The FreeFair AspectJ plugins support two approaches: _compile-time weaving_ and _post-compile weaving_.
+Choose the one that fits your project.
+
+=== Quick Start: Compile-Time Weaving
+
+Use this when your project only has Java and AspectJ sources and does not need javac-specific features like annotation processing with Lombok.
+
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+plugins {
+    id "io.freefair.aspectj" version "{revnumber}"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+dependencies {
+    implementation "org.aspectj:aspectjrt:1.9.25.1"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+plugins {
+    id("io.freefair.aspectj") version "{revnumber}"
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+dependencies {
+    implementation("org.aspectj:aspectjrt:1.9.25.1")
+}
+----
+--
+
+Place your aspects in `src/main/aspectj/` (`.aj` files) or use `@Aspect`-annotated Java classes in `src/main/java/`.
+The plugin disables the standard `compileJava` task and compiles both directories with `ajc`.
+
+[source,bash]
+----
+./gradlew compileAspectj
+----
+
+=== Quick Start: Post-Compile Weaving
+
+Use this when you need AspectJ together with annotation processors (e.g., Lombok), or with Kotlin, Groovy, or Scala sources.
+
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+plugins {
+    id "java"
+    id "io.freefair.aspectj.post-compile-weaving" version "{revnumber}"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+dependencies {
+    implementation "org.aspectj:aspectjrt:1.9.25.1"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+plugins {
+    java
+    id("io.freefair.aspectj.post-compile-weaving") version "{revnumber}"
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+dependencies {
+    implementation("org.aspectj:aspectjrt:1.9.25.1")
+}
+----
+--
+
+Your source code is compiled by `javac` first, then `ajc` weaves aspects into the resulting bytecode.
+Write your aspects as `@Aspect`-annotated classes in `src/main/java/`.
+
+NOTE: Post-compile weaving only supports pre-compiled aspects (annotation-based `@Aspect` classes or aspects provided as bytecode on the aspectpath). Native `.aj` source files require compile-time weaving.
+
+[source,bash]
+----
+./gradlew compileJava
+----
+
+TIP: For complete working examples (including multi-module setups with separate aspect libraries), see the https://github.com/freefair/gradle-plugins/tree/main/examples/aspectj[aspectj example projects].
+
 == AspectJ Plugins
 
-This chapter describes all the plugins contained in the `aspectj-plugin` module.
-
-The plugins support two different approaches when working with AspectJ:
-_Compile-time weaving_ and _post-compile weaving_.
-
-These are implemented by the `io.freefair.aspectj` and `io.freefair.aspectj.post-compile-weaving` plugins respectively.
+The `aspectj-plugin` module provides the following plugins.
+They implement _compile-time weaving_ and _post-compile weaving_ respectively.
 
 === Compile-time weaving
 

--- a/documentation/src/docs/asciidoc/_compress.adoc
+++ b/documentation/src/docs/asciidoc/_compress.adoc
@@ -5,7 +5,7 @@ https://commons.apache.org/proper/commons-compress/[The Apache Commons Compress]
 
 == Compress Plugins
 
-This chapter describes all the plugins contained in the `compress-plugin` module.
+The `compress-plugin` module provides archive and compression tasks based on Apache Commons Compress.
 
 === `io.freefair.compress`
 This plugin applies all of the plugins listed below for convenience.
@@ -210,7 +210,7 @@ tasks.register<io.freefair.gradle.plugins.compress.tasks.Deflate>("compressDefla
 [#GZip]
 === `GZip`
 
-This task can be used to compress individual files using BZip2.
+This task compresses individual files using GZip.
 
 --
 [source, groovy, role="primary"]

--- a/documentation/src/docs/asciidoc/_embedded-sass.adoc
+++ b/documentation/src/docs/asciidoc/_embedded-sass.adoc
@@ -4,9 +4,93 @@
 - https://github.com/sass/embedded-protocol
 - https://github.com/sass/dart-sass-embedded
 
-== JSass Plugins
+== Getting Started
 
-This chapter describes all the plugins contained in the `embedded-sass-plugin` module.
+The Embedded Sass plugins compile https://sass-lang.com/[Sass/SCSS] files to CSS using the https://github.com/larsgrefer/dart-sass-java[Dart Sass] embedded compiler.
+Choose the plugin variant that matches your project type.
+
+=== For Java / Resource Projects
+
+Place `.scss` files in `src/main/resources/`.
+The compiled CSS is included in the processed resources automatically.
+
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+plugins {
+    id "java"
+    id "io.freefair.sass-java" version "{revnumber}"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+plugins {
+    java
+    id("io.freefair.sass-java") version "{revnumber}"
+}
+----
+--
+
+.src/main/resources/styles/main.scss
+[source,scss]
+----
+$primary: #3366cc;
+
+body {
+  font-family: system-ui, sans-serif;
+
+  a {
+    color: $primary;
+
+    &:hover {
+      color: darken($primary, 15%);
+    }
+  }
+}
+----
+
+[source,bash]
+----
+./gradlew compileSass
+----
+
+The compiled CSS appears in `build/sass/main/` and is included in `processResources` output.
+
+=== For WAR Projects
+
+Place `.scss` files in `src/main/webapp/`.
+
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+plugins {
+    id "war"
+    id "io.freefair.sass-war" version "{revnumber}"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+plugins {
+    war
+    id("io.freefair.sass-war") version "{revnumber}"
+}
+----
+--
+
+[source,bash]
+----
+./gradlew compileWebappSass
+----
+
+TIP: For complete working examples (Java resources, WAR, and WebJars integration), see the https://github.com/freefair/gradle-plugins/tree/main/examples/embedded-sass[embedded-sass example projects].
+
+== Embedded Sass Plugins
+
+The `embedded-sass-plugin` module provides the following plugins.
 
 === `io.freefair.sass-base`
 

--- a/documentation/src/docs/asciidoc/_git.adoc
+++ b/documentation/src/docs/asciidoc/_git.adoc
@@ -2,14 +2,46 @@
 
 == Git Plugins
 
-This chapter describes all the plugins contained in the `git-plugin` module.
-
 === `io.freefair.git-version`
 
-This plugin sets the project version according to the current git tag or branch.
+This plugin sets the project version automatically based on the current Git state.
+Apply it to the root project only -- the resolved version is propagated to all subprojects.
 
-It should only be applied to the root project.
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+plugins {
+    id "io.freefair.git-version" version "{revnumber}"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+plugins {
+    id("io.freefair.git-version") version "{revnumber}"
+}
+----
+--
 
-== Git Tasks
+==== Version Resolution
 
-This module does not contain any tasks.
+The plugin resolves the version using the following strategy (in priority order):
+
+1. If the project already has an explicit version set, it is kept as-is.
+2. CI/CD environment variables are checked (GitHub Actions, GitLab CI, Travis CI, CircleCI, Jenkins).
+3. `git describe --tags --exact-match` is executed to match an exact tag.
+4. `git symbolic-ref --short HEAD` is used as a fallback to get the branch name.
+
+==== Tag and Branch Processing
+
+- *Tags* matching `vX.Y.Z` have the leading `v` stripped (e.g., `v1.2.3` becomes `1.2.3`).
+- *Release branches* matching `release-X.Y.Z` produce `X.Y.Z-SNAPSHOT`.
+- *Hotfix branches* matching `hotfix-X.Y.Z` produce `X.Y.Z-SNAPSHOT`.
+- Forward slashes in branch names are replaced with hyphens (e.g., `feature/foo` becomes `feature-foo`).
+- Dirty working trees append `-SNAPSHOT` to tag-based versions.
+
+==== Prerequisites
+
+- Git must be installed and available on the system `PATH`.
+- The project directory must be inside a Git repository.

--- a/documentation/src/docs/asciidoc/_github.adoc
+++ b/documentation/src/docs/asciidoc/_github.adoc
@@ -2,7 +2,7 @@
 
 == GitHub Plugins
 
-This chapter describes all the plugins contained in the `github-plugin` module.
+The `github-plugin` module provides plugins for GitHub integration: repository detection, POM enrichment, and publishing to the GitHub Package Registry.
 
 === `io.freefair.github.base`
 
@@ -48,10 +48,10 @@ WARNING: This plugin should only be applied to the root project.
 
 === `io.freefair.github.pom`
 
-This plugin pre-fills the pom's of all `MavenPublication`s with information avaiable from the GitHub project.
+This plugin pre-fills the POMs of all `MavenPublication` instances with information available from the GitHub project.
 
-The `scm.tag` element of the pom is auto-detected by default,
-but can be overriden using the `github.tag` extension property.
+The `scm.tag` element of the POM is auto-detected by default,
+but can be overridden using the `github.tag` extension property.
 
 TIP: This plugins calls the GitHub API.
 Configure a username and token as described in <<_io_freefair_github_base>> if

--- a/documentation/src/docs/asciidoc/_jacoco.adoc
+++ b/documentation/src/docs/asciidoc/_jacoco.adoc
@@ -5,15 +5,41 @@ https://www.eclemma.org/jacoco/[JaCoCo] is a free code coverage library for Java
 
 == JaCoCo Plugins
 
-This chapter describes all the plugins contained in the `jacoco-plugin` module.
+The `jacoco-plugin` module provides plugins for aggregating code coverage data across multi-project builds.
 
 === `io.freefair.aggregate-jacoco-report`
 
-This plugin adds a `aggregateJacocoReport` task to the project its applied on.
-This Task will generate an aggregated Jacoco report for the main java source sets of
-all projects by evaluating the execution data of the test tasks of all projects.
+This plugin adds an `aggregateJacocoReport` task to the project it is applied to.
+The task generates an aggregated JaCoCo report for the `main` source sets of all subprojects
+by collecting the execution data from their test tasks.
 
-The task is of type https://docs.gradle.org/{gradle_version}/dsl/org.gradle.testing.jacoco.tasks.JacocoReport.html[JacocoReport]
+Apply this plugin to the root project:
+
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+plugins {
+    id "io.freefair.aggregate-jacoco-report" version "{revnumber}"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+plugins {
+    id("io.freefair.aggregate-jacoco-report") version "{revnumber}"
+}
+----
+--
+
+[source,bash]
+----
+./gradlew aggregateJacocoReport
+----
+
+The aggregated report is of type https://docs.gradle.org/{gradle_version}/dsl/org.gradle.testing.jacoco.tasks.JacocoReport.html[JacocoReport].
+
+TIP: For a multi-module example, see the https://github.com/freefair/gradle-plugins/tree/main/examples/jacoco[jacoco example project].
 
 == JaCoCo Tasks
 
@@ -21,7 +47,8 @@ The task is of type https://docs.gradle.org/{gradle_version}/dsl/org.gradle.test
 
 The
 link:../api/io/freefair/gradle/plugins/jacoco/tasks/JacocoDump.html[`io.freefair.gradle.plugins.jacoco.tasks.JacocoDump`]
-task is the Gradle equivalent of the https://www.jacoco.org/jacoco/trunk/doc/ant.html#dump[`dump` Ant-Task]
+task is the Gradle equivalent of the https://www.jacoco.org/jacoco/trunk/doc/ant.html#dump[`dump` Ant-Task].
+It connects to a remote JaCoCo agent via TCP and downloads execution data.
 
 .JacocoDump Example
 --

--- a/documentation/src/docs/asciidoc/_lombok.adoc
+++ b/documentation/src/docs/asciidoc/_lombok.adoc
@@ -4,9 +4,66 @@
 https://projectlombok.org/[Project Lombok] is a java library that automatically plugs into your editor and build tools, spicing up your java.
 Never write another getter or equals method again, with one annotation your class has a fully featured builder, Automate your logging variables, and much more.
 
+== Getting Started
+
+Apply the plugin and you are done -- no manual dependency management required.
+
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+plugins {
+    id "java"
+    id "io.freefair.lombok" version "{revnumber}"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+plugins {
+    java
+    id("io.freefair.lombok") version "{revnumber}"
+}
+----
+--
+
+The plugin adds Lombok to `annotationProcessor` and `compileOnly` for every source set automatically.
+Use Lombok annotations in your Java sources right away:
+
+[source,java]
+----
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@Slf4j
+public class User {
+    private String name;
+    private String email;
+}
+----
+
+Build as usual:
+
+[source,bash]
+----
+./gradlew build
+----
+
+To inspect the generated code, run `delombok`:
+
+[source,bash]
+----
+./gradlew delombok
+----
+
+The delomboked sources appear in `build/delombok/`.
+
+TIP: For a complete working example (including MapStruct integration), see the https://github.com/freefair/gradle-plugins/tree/main/examples/lombok[lombok example project].
+
 == Lombok Plugins
 
-This chapter describes all the plugins contained in the `lombok-plugin` module.
+The `lombok-plugin` module provides the following plugins.
 
 === `io.freefair.lombok-base`
 

--- a/documentation/src/docs/asciidoc/_maven-plugin.adoc
+++ b/documentation/src/docs/asciidoc/_maven-plugin.adoc
@@ -1,19 +1,54 @@
-= Maven-Plugin
+= Maven Plugin
 
-== Maven-Plugin Plugins
-
-This chapter describes all the plugins contained in the `maven-plugin-plugin` module.
+== Maven Plugin Plugins
 
 === `io.freefair.maven-plugin`
 
-This plugin can be used to build maven plugins.
-It's based on the `java` and `maven-publish` plugins.
+Use this plugin to build https://maven.apache.org/plugin-tools/[Maven plugins] with Gradle.
+It applies the `java` and `maven-publish` plugins, sets the POM packaging to `maven-plugin`,
+and generates a Maven plugin descriptor from your annotated source code.
 
-== Maven-Plugin Tasks
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+plugins {
+    id "io.freefair.maven-plugin" version "{revnumber}"
+}
+
+dependencies {
+    implementation "org.apache.maven:maven-plugin-api:3.9.9"
+    implementation "org.apache.maven.plugin-tools:maven-plugin-annotations:3.16.0"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+plugins {
+    id("io.freefair.maven-plugin") version "{revnumber}"
+}
+
+dependencies {
+    implementation("org.apache.maven:maven-plugin-api:3.9.9")
+    implementation("org.apache.maven.plugin-tools:maven-plugin-annotations:3.16.0")
+}
+----
+--
+
+Annotate your Mojo classes with `@Mojo`, `@Parameter`, etc. as usual.
+The plugin descriptor is generated automatically during the build.
+
+TIP: For a working example, see the https://github.com/freefair/gradle-plugins/tree/main/examples/test-maven-plugin[test-maven-plugin example project].
+
+== Maven Plugin Tasks
 
 === `DescriptorGeneratorTask`
 
-This Task is the gradle equivalent of the
+Generates the Maven plugin descriptor (`plugin.xml`) from annotated source files.
+This is the Gradle equivalent of the
 https://maven.apache.org/plugin-tools/maven-plugin-plugin/descriptor-mojo.html[`DescriptorGeneratorMojo`]
-of the
-https://maven.apache.org/plugin-tools/maven-plugin-plugin/index.html[Maven Plugin Maven Plugin].
+from the
+https://maven.apache.org/plugin-tools/maven-plugin-plugin/index.html[Maven Plugin Plugin].
+
+The generated descriptor is placed in `build/generated/resources/maven-plugin-descriptor`
+and automatically included in the main source set resources.

--- a/documentation/src/docs/asciidoc/_maven.adoc
+++ b/documentation/src/docs/asciidoc/_maven.adoc
@@ -2,7 +2,7 @@
 
 == Maven Plugins
 
-This chapter describes all the plugins contained in the `maven-plugin` module.
+The `maven-plugin` module provides Maven-like features for Gradle: WAR overlays, Javadoc aggregation, Maven Central publishing helpers, and more.
 
 === `io.freefair.war`
 

--- a/documentation/src/docs/asciidoc/_mjml.adoc
+++ b/documentation/src/docs/asciidoc/_mjml.adoc
@@ -1,17 +1,49 @@
 = MJML
 
-- https://mjml.io/
-- https://github.com/mjmlio/mjml/blob/master/packages/mjml-cli/README.md
-- https://github.com/node-gradle/gradle-node-plugin
+https://mjml.io/[MJML] is a markup language for responsive email templates.
+It compiles to standard HTML that renders consistently across email clients.
 
-== MJML Plugin
+== Getting Started
 
-This chapter describes all the plugins contained in the `mjml-plugin` module.
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+plugins {
+    id "java"
+    id "io.freefair.mjml.java" version "{revnumber}"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+plugins {
+    java
+    id("io.freefair.mjml.java") version "{revnumber}"
+}
+----
+--
+
+Place `.mjml` files in `src/main/mjml/`.
+The compiled HTML is added to the Java resource output automatically.
+
+[source,bash]
+----
+./gradlew compileMjml
+----
+
+NOTE: MJML is installed automatically via npm (requires Node.js on the system `PATH`).
+The plugin uses the https://github.com/node-gradle/gradle-node-plugin[gradle-node-plugin] under the hood.
+
+TIP: For a working example, see the https://github.com/freefair/gradle-plugins/tree/main/examples/mjml[mjml example project].
+
+== MJML Plugins
 
 === `io.freefair.mjml.base`
 
-This plugin adds the `mjml` extension to the project and create some basic tasks to install mjml via npm.
+This plugin adds the `mjml` extension to the project and installs MJML via npm.
 
+.Configuration options
 --
 [source, groovy, role="primary"]
 .Groovy
@@ -25,7 +57,7 @@ mjml {
     juicePreserveTags = "{\"myTag\": { \"start\": \"<#\", \"end\": \"</#\" }}"
 }
 ----
-[source,kotlin, role="secondary"]
+[source, kotlin, role="secondary"]
 .Kotlin
 ----
 mjml {
@@ -41,8 +73,10 @@ mjml {
 
 === `io.freefair.mjml.java`
 
-This plugin adds the mjml compile task output to java's resources.
+Applies the base plugin and adds the MJML compile task output to the Java resource processing pipeline.
 
-== MJML Task
+== MJML Tasks
 
-Compiles your mjml files to html with the given configuration (see extension documentation).
+=== `CompileMjml`
+
+Compiles `.mjml` files to `.html` using the MJML CLI with the configuration from the `mjml` extension.

--- a/documentation/src/docs/asciidoc/_mkdocs.adoc
+++ b/documentation/src/docs/asciidoc/_mkdocs.adoc
@@ -4,28 +4,81 @@
 MkDocs is a fast, simple and downright gorgeous static site generator that's geared towards building project documentation.
 Documentation source files are written in Markdown, and configured with a single YAML configuration file.
 
+== Getting Started
+
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+plugins {
+    id "io.freefair.mkdocs" version "{revnumber}"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+plugins {
+    id("io.freefair.mkdocs") version "{revnumber}"
+}
+----
+--
+
+NOTE: MkDocs must be installed on your system (`pip install mkdocs`).
+The plugin calls the `mkdocs` CLI under the hood.
+
+Initialize a new MkDocs project:
+
+[source,bash]
+----
+./gradlew mkdocsNew
+----
+
+Start the development server:
+
+[source,bash]
+----
+./gradlew mkdocsServe
+----
+
+Build the documentation:
+
+[source,bash]
+----
+./gradlew mkdocs
+----
+
+The built site appears in `build/docs/mkdocs/` by default.
+
+TIP: For a working example, see the https://github.com/freefair/gradle-plugins/tree/main/examples/mkdocs[mkdocs example project].
+
 == MkDocs Plugins
 
 === `io.freefair.mkdocs`
 
+This plugin registers all MkDocs tasks listed below.
+It expects a `mkdocs.yml` configuration file in the project root directory.
+
 == MkDocs Tasks
 
-All MkDocs tasks can be found in the
+All tasks are in the `documentation` group.
+Full API documentation is available in the
 link:../api/io/freefair/gradle/plugins/mkdocs/tasks/package-summary.html[`io.freefair.gradle.plugins.mkdocs.tasks`]
-package
+package.
 
 === `MkDocsBuild`
 
-This tasks executes `mkdocs build`.
+Executes `mkdocs build` to generate a static documentation site.
 
-=== `MkDocsGhDeploy`
-
-This task executes `mkdocs gh-deploy`
-
-=== `MkDocsNew`
-
-This task executes `mkdocs new`
+Output directory convention: `build/docs/mkdocs`.
 
 === `MkDocsServe`
 
-This tasks executes `mkdocs serve`
+Executes `mkdocs serve` to start a local development server with live-reload.
+
+=== `MkDocsNew`
+
+Executes `mkdocs new` to scaffold a fresh MkDocs project with a default `mkdocs.yml` and `docs/index.md`.
+
+=== `MkDocsGhDeploy`
+
+Executes `mkdocs gh-deploy` to publish the documentation to GitHub Pages.

--- a/documentation/src/docs/asciidoc/_okhttp.adoc
+++ b/documentation/src/docs/asciidoc/_okhttp.adoc
@@ -5,7 +5,7 @@ An HTTP & HTTP/2 client for Android and Java applications
 
 == OkHttp Plugins
 
-== Apply plugin
+=== Apply plugin
 --
 [source, groovy, role="primary"]
 .Groovy

--- a/documentation/src/docs/asciidoc/_plantuml.adoc
+++ b/documentation/src/docs/asciidoc/_plantuml.adoc
@@ -20,7 +20,10 @@ plugins {
 }
 ----
 --
-This adds a PlantUML task to gradle as well as a new source set. The images will be saved to the build directory.
+This adds a PlantUML task to Gradle as well as a new source set.
+Place `.puml` files in `src/plantuml/` and the generated images will be saved to the build directory.
+
+TIP: For a working example, see the https://github.com/freefair/gradle-plugins/tree/main/examples/plantuml[plantuml example project].
 
 == Configuration options
 

--- a/documentation/src/docs/asciidoc/_quickref.adoc
+++ b/documentation/src/docs/asciidoc/_quickref.adoc
@@ -1,0 +1,146 @@
+= Plugin Quick Reference
+
+Use this table to find the right plugin for your use case.
+All plugin IDs follow the pattern `io.freefair.<name>`.
+
+== Build & Compilation
+
+[cols="2,3", options="header"]
+|===
+| Plugin ID | Purpose
+
+| `io.freefair.lombok`
+| Automates https://projectlombok.org/[Lombok] setup: adds annotation processor, creates `delombok` tasks, configures Javadoc.
+
+| `io.freefair.aspectj`
+| Compile-time AspectJ weaving. Replaces `javac` with `ajc`. Supports `.aj` and `@Aspect` sources.
+
+| `io.freefair.aspectj.post-compile-weaving`
+| Post-compile AspectJ weaving. Runs `ajc` after `javac`/`kotlinc`/`groovyc`. Use with Lombok or Kotlin.
+
+| `io.freefair.sass-java`
+| Compiles Sass/SCSS files from `src/main/resources/` to CSS using https://github.com/larsgrefer/dart-sass-java[Dart Sass].
+
+| `io.freefair.sass-war`
+| Compiles Sass/SCSS files from `src/main/webapp/` for WAR projects.
+
+| `io.freefair.sass-webjars`
+| Adds https://www.webjars.org/[WebJars] support to Sass compilation (e.g., `@import "scss/bootstrap"`).
+
+| `io.freefair.mjml.java`
+| Compiles https://mjml.io/[MJML] email templates to HTML as part of resource processing.
+
+| `io.freefair.gwt`
+| Google Web Toolkit compilation and DevMode integration.
+
+| `io.freefair.plantuml`
+| Generates images (PNG, SVG, etc.) from https://plantuml.com/[PlantUML] diagram files.
+
+| `io.freefair.compress`
+| Provides Ar, Cpio, 7z archive tasks and GZip, BZip2, LZMA, Deflate compression tasks via Apache Commons Compress.
+
+| `io.freefair.code-generator`
+| Framework for custom code generation plugins.
+
+| `io.freefair.quicktype`
+| Generates code from JSON Schema using https://quicktype.io/[quicktype].
+
+| `io.freefair.maven-plugin`
+| Build Maven plugins using Gradle. Generates Maven plugin descriptors.
+|===
+
+== Documentation
+
+[cols="2,3", options="header"]
+|===
+| Plugin ID | Purpose
+
+| `io.freefair.aggregate-javadoc`
+| Aggregates Javadoc from multiple subprojects into a single documentation set. Apply to the root project.
+
+| `io.freefair.javadocs`
+| Adds a `javadocJar` task and publishes it alongside the main artifact.
+
+| `io.freefair.javadoc-links`
+| Automatically resolves and adds `-link` arguments to Javadoc tasks based on dependencies.
+
+| `io.freefair.javadoc-utf-8`
+| Sets UTF-8 encoding for all Javadoc tasks.
+
+| `io.freefair.mkdocs`
+| Integrates https://www.mkdocs.org/[MkDocs] into the Gradle build for documentation generation.
+|===
+
+== Publishing
+
+[cols="2,3", options="header"]
+|===
+| Plugin ID | Purpose
+
+| `io.freefair.maven-publish-java`
+| Configures `maven-publish` for Java libraries with sources and Javadoc JARs.
+
+| `io.freefair.maven-publish-war`
+| Configures `maven-publish` for WAR projects.
+
+| `io.freefair.github.package-registry-maven-publish`
+| Publishes artifacts to the GitHub Package Registry.
+
+| `io.freefair.maven-central.validate-poms`
+| Validates that generated POM files meet Maven Central requirements.
+
+| `io.freefair.maven-optional`
+| Adds an `optional` configuration similar to Maven's `<optional>true</optional>`.
+|===
+
+== Project Setup & Utilities
+
+[cols="2,3", options="header"]
+|===
+| Plugin ID | Purpose
+
+| `io.freefair.settings.plugin-versions`
+| Apply in `settings.gradle` to manage FreeFair plugin versions in one place. Subprojects can omit the version.
+
+| `io.freefair.git-version`
+| Sets the project version based on the current Git tag or branch. Apply to the root project only.
+
+| `io.freefair.github.base`
+| Detects the GitHub repository slug and provides a shared `GithubExtension` for other GitHub plugins.
+
+| `io.freefair.github.pom`
+| Fills POM metadata (URL, SCM, license, developers) from the GitHub API.
+
+| `io.freefair.okhttp`
+| Provides a shared https://square.github.io/okhttp/[OkHttpClient] and HTTP tasks (download, upload, request).
+
+| `io.freefair.war`
+| Adds Maven-like WAR features (attached classes, archive classes).
+
+| `io.freefair.war-overlay`
+| Adds Maven-like WAR overlay support for merging WARs.
+
+| `io.freefair.aggregate-jacoco-report`
+| Aggregates JaCoCo code coverage reports from multiple subprojects.
+|===
+
+== Base Plugins
+
+Base plugins provide shared infrastructure and are applied automatically by the higher-level plugins listed above. You typically do not need to apply these directly.
+
+[cols="2,3", options="header"]
+|===
+| Plugin ID | Applied by
+
+| `io.freefair.aspectj.base`
+| `io.freefair.aspectj`, `io.freefair.aspectj.post-compile-weaving`
+
+| `io.freefair.sass-base`
+| `io.freefair.sass-java`, `io.freefair.sass-war`
+
+| `io.freefair.gwt-base`
+| `io.freefair.gwt`
+
+| `io.freefair.mjml.base`
+| `io.freefair.mjml.java`
+|===

--- a/documentation/src/docs/asciidoc/_settings.adoc
+++ b/documentation/src/docs/asciidoc/_settings.adoc
@@ -2,11 +2,50 @@
 
 == Settings Plugins
 
-This chapter describes all the plugins contained in the `settings-plugin` module.
-
 === `io.freefair.settings.plugin-versions`
 
-This plugin allows you to use all other plugins, without defining their version.
+Apply this plugin in `settings.gradle(.kts)` to manage FreeFair plugin versions in one place.
+Once applied, all FreeFair plugins can be used in subprojects without specifying a version.
 
-NOTE: This plugin must be applied in settings.gradle(.kts)
+--
+[source,groovy,subs=attributes+,role="primary"]
+.Groovy
+----
+// settings.gradle
+plugins {
+    id "io.freefair.settings.plugin-versions" version "{revnumber}"
+}
+----
+[source,kotlin,subs=attributes+,role="secondary"]
+.Kotlin
+----
+// settings.gradle.kts
+plugins {
+    id("io.freefair.settings.plugin-versions") version "{revnumber}"
+}
+----
+--
 
+In your subproject build files, the version can then be omitted:
+
+--
+[source,groovy,role="primary"]
+.Groovy
+----
+// build.gradle (subproject)
+plugins {
+    id "io.freefair.lombok" // no version needed
+}
+----
+[source,kotlin,role="secondary"]
+.Kotlin
+----
+// build.gradle.kts (subproject)
+plugins {
+    id("io.freefair.lombok") // no version needed
+}
+----
+--
+
+The plugin reads all known FreeFair plugin IDs from the classpath and registers them in the settings
+https://docs.gradle.org/{gradle_version}/userguide/plugins.html#sec:plugin_management[plugin management] block with the matching version.

--- a/documentation/src/docs/asciidoc/index.adoc
+++ b/documentation/src/docs/asciidoc/index.adoc
@@ -107,6 +107,8 @@ Some plugins may interface with the Kotlin Gradle plugin or are implemented in K
 
 Whenever possible, we use the same Kotlin version that Gradle uses, currently {kotlin_version}.
 
+include::_quickref.adoc[]
+
 include::_settings.adoc[]
 
 include::_aspectj.adoc[]

--- a/documentation/src/docs/asciidoc/llms.txt
+++ b/documentation/src/docs/asciidoc/llms.txt
@@ -1,0 +1,60 @@
+# FreeFair Gradle Plugins
+
+> A collection of 45+ Gradle plugins for Lombok, AspectJ, SASS, PlantUML, Maven integration, GitHub publishing, and more.
+
+All plugin IDs follow the pattern `io.freefair.<name>`. Since version 8, the major.minor version aligns with Gradle's version (e.g., plugin 9.x targets Gradle 9.x). Java 17+ required.
+
+## Docs
+
+- [Reference Guide](https://docs.freefair.io/gradle-plugins/current/reference/): Complete plugin documentation (AsciiDoc, single-page)
+- [Javadoc API](https://docs.freefair.io/gradle-plugins/current/api/): API documentation for all plugin classes
+- [Examples](https://github.com/freefair/gradle-plugins/tree/main/examples): Working example projects for most plugins
+- [Source Code](https://github.com/freefair/gradle-plugins): GitHub repository
+
+## Build & Compilation Plugins
+
+- `io.freefair.lombok`: Automates Lombok setup. Zero-config: just apply the plugin. Adds annotation processor, creates delombok tasks, configures Javadoc.
+- `io.freefair.aspectj`: AspectJ compile-time weaving. Replaces javac with ajc. Supports .aj and @Aspect sources. Place aspects in src/main/aspectj/.
+- `io.freefair.aspectj.post-compile-weaving`: AspectJ post-compile weaving. Runs ajc after javac/kotlinc/groovyc. Use with Lombok or Kotlin. Only supports @Aspect classes, not .aj files.
+- `io.freefair.sass-java`: Compiles Sass/SCSS files from src/main/resources/ to CSS using Dart Sass. Output included in processResources.
+- `io.freefair.sass-war`: Compiles Sass/SCSS files from src/main/webapp/ for WAR projects.
+- `io.freefair.sass-webjars`: Adds WebJars support to Sass compilation (e.g., @import "scss/bootstrap").
+- `io.freefair.mjml.java`: Compiles MJML email templates to HTML. Requires Node.js. Output added to Java resources.
+- `io.freefair.gwt`: Google Web Toolkit compilation and DevMode integration.
+- `io.freefair.plantuml`: Generates images (PNG, SVG, etc.) from PlantUML diagram files in src/plantuml/.
+- `io.freefair.compress`: Archive and compression tasks (Ar, Cpio, 7z, GZip, BZip2, LZMA, Deflate) via Apache Commons Compress.
+- `io.freefair.code-generator`: Framework for custom code generation plugins.
+- `io.freefair.quicktype`: Generates code from JSON Schema using quicktype.
+- `io.freefair.maven-plugin`: Build Maven plugins using Gradle. Generates Maven plugin descriptors.
+
+## Documentation Plugins
+
+- `io.freefair.aggregate-javadoc`: Aggregates Javadoc from multiple subprojects. Apply to root project. Add subprojects via `javadoc` configuration dependencies.
+- `io.freefair.javadocs`: Adds a javadocJar task and publishes it alongside the main artifact.
+- `io.freefair.javadoc-links`: Automatically resolves and adds -link arguments to Javadoc tasks based on dependencies.
+- `io.freefair.javadoc-utf-8`: Sets UTF-8 encoding for all Javadoc tasks.
+- `io.freefair.mkdocs`: Integrates MkDocs into the Gradle build. Requires MkDocs installed on the system. Tasks: mkdocs (build), mkdocsServe, mkdocsNew.
+
+## Publishing Plugins
+
+- `io.freefair.maven-publish-java`: Configures maven-publish for Java libraries with sources and Javadoc JARs.
+- `io.freefair.maven-publish-war`: Configures maven-publish for WAR projects.
+- `io.freefair.github.package-registry-maven-publish`: Publishes artifacts to the GitHub Package Registry. Requires GitHub token.
+- `io.freefair.maven-central.validate-poms`: Validates that generated POM files meet Maven Central requirements.
+- `io.freefair.maven-optional`: Adds an "optional" configuration similar to Maven's optional dependency scope.
+
+## Utility Plugins
+
+- `io.freefair.settings.plugin-versions`: Apply in settings.gradle to manage FreeFair plugin versions in one place. Subprojects can omit the version.
+- `io.freefair.git-version`: Sets project version based on Git tag or branch. Supports GitHub Actions, GitLab CI, Travis CI, CircleCI, Jenkins. Apply to root project only.
+- `io.freefair.github.base`: Detects GitHub repository slug. Provides GithubExtension for other GitHub plugins. Apply to root project only.
+- `io.freefair.github.pom`: Fills POM metadata (URL, SCM, license, developers) from the GitHub API.
+- `io.freefair.okhttp`: Provides a shared OkHttpClient and HTTP tasks (DownloadFile, UploadFile).
+- `io.freefair.war`: Adds Maven-like WAR features (attached classes, archive classes).
+- `io.freefair.war-overlay`: Adds Maven-like WAR overlay support for merging multiple WARs.
+- `io.freefair.aggregate-jacoco-report`: Aggregates JaCoCo code coverage reports from multiple subprojects. Apply to root project.
+
+## Optional
+
+- [Gradle Plugin Portal](https://plugins.gradle.org/search?term=io.freefair): All plugins on the Gradle Plugin Portal
+- [Compatibility Matrix](https://github.com/freefair/gradle-plugins#compatibility): Plugin version to Gradle/Java/Kotlin version mapping

--- a/examples/aspectj/weaving/build.gradle
+++ b/examples/aspectj/weaving/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "org.jetbrains.kotlin.jvm"
     id "org.springframework.boot" version "4.0.5"
-    id "org.graalvm.buildtools.native" version "0.11.3"
+    id "org.graalvm.buildtools.native" version "1.0.0"
 }
 
 apply plugin: "io.freefair.aspectj.post-compile-weaving"


### PR DESCRIPTION
## Summary

Comprehensive documentation overhaul addressing #1022 and long-standing gaps:

- **Getting Started sections** for Lombok, AspectJ (compile-time + post-compile), and Embedded SASS with complete, copy-paste-ready examples in both Groovy and Kotlin DSL
- **Plugin Quick Reference** page categorizing all 47 plugins by use case (Build, Documentation, Publishing, Utilities)
- **llms.txt** following the [llms.txt specification](https://llmstxt.org/) for AI-friendly documentation consumption
- **Stub docs expanded**: Settings, Git, MkDocs, and Maven Plugin now have real content with examples
- **Language consistency** across all 14 AsciiDoc files: removed boilerplate, fixed typos, corrected copy-paste errors, added missing introductions
- **Example version update**: GraalVM Native Build Tools 0.11.3 → 1.0.0

### Files changed (19)
- 2 new: `_quickref.adoc`, `llms.txt`
- 15 modified AsciiDoc files
- 1 modified `build.gradle` (llms.txt copy task)
- 1 modified example `build.gradle` (version bump)

Closes #1022

## Test plan

- [x] `./gradlew :documentation:asciidoctor` builds successfully
- [x] Groovy/Kotlin tabs render and switch correctly in the generated HTML
- [x] `{revnumber}` resolves in all new code blocks
- [x] `llms.txt` is present in `documentation/build/docs/asciidoc/`
- [x] TOC hierarchy in index.html is clean
- [x] Example project `examples/aspectj/weaving` still builds