### PR TITLE
Support JPMS projects in delombok by wiring module path

### DIFF
--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -116,10 +116,18 @@ public class LombokPlugin implements Plugin<Project> {
 
             delombokTaskProvider.configure(delombok -> {
                 delombok.getEncoding().set(compileTaskProvider.map(c -> c.getOptions().getEncoding()));
-                delombok.getClasspath().from(sourceSet.getCompileClasspath());
                 delombok.getInput().from(sourceSet.getJava().getSourceDirectories());
                 delombok.getSourcepath().from(compileTaskProvider.flatMap(c -> c.getOptions().getGeneratedSourceOutputDirectory()));
                 delombok.dependsOn(sourceSet.getJava().getBuildDependencies());
+
+                boolean hasModuleInfo = !sourceSet.getJava().getSourceDirectories()
+                        .getAsFileTree().matching(pattern -> pattern.include("**/module-info.java")).isEmpty();
+
+                if (hasModuleInfo) {
+                    delombok.getModulePath().from(sourceSet.getCompileClasspath());
+                } else {
+                    delombok.getClasspath().from(sourceSet.getCompileClasspath());
+                }
             });
         });
 

--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -121,7 +121,7 @@ public class LombokPlugin implements Plugin<Project> {
                 delombok.dependsOn(sourceSet.getJava().getBuildDependencies());
 
                 boolean hasModuleInfo = !sourceSet.getJava().getSourceDirectories()
-                        .getAsFileTree().matching(pattern -> pattern.include("**/module-info.java")).isEmpty();
+                        .getAsFileTree().matching(pattern -> pattern.include("module-info.java")).isEmpty();
 
                 if (hasModuleInfo) {
                     delombok.getModulePath().from(sourceSet.getCompileClasspath());

--- a/lombok-plugin/src/test/java/io/freefair/gradle/plugins/lombok/DelombokTest.java
+++ b/lombok-plugin/src/test/java/io/freefair/gradle/plugins/lombok/DelombokTest.java
@@ -14,6 +14,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DelombokTest extends AbstractPluginTest {
 
     @Test
+    public void jpmsDelombokTest() {
+        createGradleConfiguration()
+                .applyPlugin("java")
+                .applyPlugin("io.freefair.lombok")
+                .addCustomConfigurationBlock("delombok.target = file('src/main-delombok/java/')")
+                .write();
+
+        TypeSpec.Builder builder = TypeSpec.classBuilder("ModularUser")
+                .addModifiers(Modifier.PUBLIC);
+        builder.addField(FieldSpec.builder(String.class, "name", Modifier.PRIVATE).build());
+        builder.addField(FieldSpec.builder(String.class, "email", Modifier.PRIVATE).build());
+        builder.addAnnotation(AnnotationSpec.builder(lombok.Data.class).build());
+
+        createJavaClass("main", "io.freefair.gradle.plugins.lombok.test", builder.build());
+
+        createFile("src/main/java", "module-info.java")
+                .append("module io.freefair.gradle.plugins.lombok.test {\n")
+                .append("    requires static lombok;\n")
+                .append("}\n")
+                .write();
+
+        executeTask("delombok", "--debug");
+        String modularUser = readJavaClass("main-delombok", "io.freefair.gradle.plugins.lombok.test", "ModularUser");
+        assertThat(modularUser).doesNotContain("lombok.Data");
+    }
+
+    @Test
     public void simpleDelombokTest() {
         createGradleConfiguration()
                 .applyPlugin("java")


### PR DESCRIPTION
## Summary

- When `module-info.java` is present in a source set, put the compile classpath on `--module-path` instead of `--classpath` so that javac (inside lombok) can resolve module dependencies
- The `Delombok` task already had a `modulePath` property and generated `--module-path` arguments, but the `LombokPlugin` never configured it
- Non-modular projects are completely unaffected (conditional detection)
- Added a test that verifies delombok works with `module-info.java` containing `requires static lombok`

Note: Lombok itself has known JPMS limitations (projectlombok/lombok#2829, projectlombok/lombok#3389) that may still cause issues in complex module setups. This fix addresses the plugin-level gap where the module path was never passed to delombok at all.

Closes #1597

## Test plan

- [x] New `jpmsDelombokTest` passes
- [x] Existing `simpleDelombokTest` still passes (non-JPMS unaffected)
- [x] Full `./gradlew check` passes (310 tasks)