### PR TITLE
Skip AJC when compile task produced no output

### DIFF
--- a/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AjcAction.java
+++ b/aspectj-plugin/src/main/java/io/freefair/gradle/plugins/aspectj/AjcAction.java
@@ -110,6 +110,11 @@ public class AjcAction implements Action<Task> {
             return true;
         }
 
+        if (hasNoCompileOutput(task)) {
+            task.getLogger().lifecycle("Skipping AJC for task '{}' (compile task produced no output)", task.getPath());
+            return true;
+        }
+
         if (!getOptions().getAspectpath().isEmpty()) {
             task.getLogger().info("Not skipping AJC (aspectpath is set)");
             return false;
@@ -167,6 +172,21 @@ public class AjcAction implements Action<Task> {
         spec.setLauncher(launcher.getOrNull());
 
         return spec;
+    }
+
+    private static boolean hasNoCompileOutput(Task task) {
+        File outputDir = null;
+        if (task instanceof AbstractCompile) {
+            outputDir = ((AbstractCompile) task).getDestinationDirectory().get().getAsFile();
+        } else if (task instanceof KotlinJvmCompile) {
+            outputDir = ((KotlinJvmCompile) task).getDestinationDirectory().get().getAsFile();
+        }
+
+        if (outputDir == null) {
+            return false;
+        }
+
+        return !outputDir.exists() || outputDir.list() == null || outputDir.list().length == 0;
     }
 
     public static Stream<File> getCompileClasspath(Task task) {


### PR DESCRIPTION
## Summary

- In Kotlin-only projects, `compileJava` has no sources but the post-compile weaving plugin still attaches an AJC action to it
- When `inpath` or `aspectpath` is configured, AJC does not skip and fails on the empty/non-existent output directory
- Now checks the compile task's destination directory before running AJC -- if it doesn't exist or is empty, the action is skipped with a lifecycle log message
- Non-Kotlin projects and compile tasks with actual output are completely unaffected

### Follow-up: bootJar error from @c0ldd

The `bootJar` error reported in the last comment is a **user configuration issue**, not a plugin bug. The user's project declares both `implementation(project("demo-api"))` and `inpath(files("demo-api/...jar"))` simultaneously, causing duplicate `META-INF/MANIFEST.MF` entries. The fix is to use one or the other, or set `duplicatesStrategy = DuplicatesStrategy.EXCLUDE` on `bootJar`. A comment will be added to the issue.

Closes #1368

## Test plan

- [x] `./gradlew :aspectj-plugin:test` passes
- [x] Full `./gradlew check` passes (310 tasks)
- [x] Existing AspectJ weaving example still builds