### PR TITLE
fix: Separate try/catch for license and user fetch in GithubPomPlugin

### DIFF
--- a/github-plugin/src/main/java/io/freefair/gradle/plugins/github/GithubPomPlugin.java
+++ b/github-plugin/src/main/java/io/freefair/gradle/plugins/github/GithubPomPlugin.java
@@ -54,11 +54,16 @@ public class GithubPomPlugin implements Plugin<Project> {
                 if (repo.getLicense() != null && hasText(repo.getLicense().getUrl())) {
                     ghLicense = githubService.getLicense(repo.getLicense().getUrl()).execute().body();
                 }
+            } catch (IOException e) {
+                project.getLogger().warn("Failed to fetch GitHub license info for '{}': {}", slug, e.getMessage());
+            }
+
+            try {
                 if (githubExtension.getOwner().isPresent()) {
                     user = githubService.getUser(githubExtension.getOwner().get()).execute().body();
                 }
             } catch (IOException e) {
-                project.getLogger().warn("Failed to fetch GitHub user/license info for '{}': {}", slug, e.getMessage());
+                project.getLogger().warn("Failed to fetch GitHub user info for '{}': {}", slug, e.getMessage());
             }
 
             project.getPlugins().withType(PublishingPlugin.class, publishingPlugin -> {


### PR DESCRIPTION
## Summary
- Split the combined try/catch in `GithubPomPlugin.afterEvaluate` into two independent blocks — one for the license fetch, one for the user fetch
- A failing license API call no longer silently prevents the user fetch (and vice versa)
- Error messages now specify which fetch failed instead of the generic "user/license" message

Found during automated main branch review (PR maintenance).

## Test plan
- [x] All project tests pass locally (`./gradlew check`)
- [ ] Verify GitHub POM enrichment still works when both API calls succeed
- [ ] Verify that a license fetch failure does not suppress the organization block in the POM