### PR TITLE
fix(delombok): add sourcepath when module-info.java is present

### DIFF
--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/LombokPlugin.java
@@ -122,6 +122,7 @@ public class LombokPlugin implements Plugin<Project> {
 
                 if (hasModuleInfo) {
                     delombok.getModulePath().from(sourceSet.getCompileClasspath());
+                    delombok.getSourcepath().from(sourceSet.getJava().getSourceDirectories());
                 } else {
                     delombok.getClasspath().from(sourceSet.getCompileClasspath());
                 }


### PR DESCRIPTION
## Problem

When a source set contains `module-info.java`, the delombok task already sets
`modulePath` from the compile classpath (added in the `hasModuleInfo` branch).
However, the source directories are not added to `sourcepath` in that case.

This causes javac (invoked internally by Lombok's delombok) to emit errors for
every source file in the compilation unit:

```
error: file should be on source path, or on patch path for module
```

These errors are non-fatal — delombok still produces correct output — but they
are noisy and misleading.

## Root cause

When javac processes `module-info.java` in module mode, it requires the module's
source root to be declared via `--source-path` so it can correctly associate
source files with the named module. Without it, javac cannot determine which
module the input files belong to.

The plugin already adds the annotation processor output directory to `sourcepath`
(line 117), but omits the actual source directories when `module-info.java` is
present.

## Fix

Add `sourceSet.getJava().getSourceDirectories()` to the sourcepath in the same
`hasModuleInfo` branch that already configures the module path:

```java
if (hasModuleInfo) {
    delombok.getModulePath().from(sourceSet.getCompileClasspath());
    delombok.getSourcepath().from(sourceSet.getJava().getSourceDirectories());
}
```