### PR TITLE
delombok: preserve all input dirs

### DIFF
--- a/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/Delombok.java
+++ b/lombok-plugin/src/main/java/io/freefair/gradle/plugins/lombok/tasks/Delombok.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.*;
-import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.*;
 import org.gradle.jvm.toolchain.JavaLauncher;
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 public abstract class Delombok extends DefaultTask implements LombokTask {
 
     @Inject
-    protected abstract FileOperations getFileOperations();
+    protected abstract ObjectFactory getObjectFactory();
 
     @Inject
     protected abstract FileSystemOperations getFileSystemOperations();
@@ -133,19 +133,14 @@ public abstract class Delombok extends DefaultTask implements LombokTask {
     @SkipWhenEmpty
     @IgnoreEmptyDirectories
     protected FileTree getFilteredInput() {
-        ConfigurableFileTree fileTree = null;
+        ConfigurableFileCollection dirs = getObjectFactory().fileCollection();
 
-        for (File file : getInput().getFiles()) {
-            if (file.isDirectory()) {
-                if (fileTree == null) {
-                    fileTree = getFileOperations().fileTree(file);
-                } else {
-                    fileTree.from(file);
-                }
-            }
-        }
+        getInput().getFiles()
+                .stream()
+                .filter(File::isDirectory)
+                .forEach(dirs::from);
 
-        return fileTree;
+        return dirs.getAsFileTree();
     }
 
     @TaskAction


### PR DESCRIPTION
A source set that has multiple input dirs would only preserve the last-registered one during getFilteredInput's reduction. This could cause erroneous UP-TO-DATE results and stale cache outputs.

The bugged line is `fileTree.from(file)`, which **overwrites** the file tree instead of merging them. Added in a3b889b985f39c10fe754c65153850d2bbe29c60.

Reproduction is quite simple:

1. Add a second input directory to an already existing source set: `sourceSets.main { java.srcDirs("src/main2/java") }`
2. Ensure that directory is not empty.
3. Note that changes now to the first dir (src/main/java) does not trigger a re-processing of delombok, with gradle reporting UP-TO-DATE.

Extended setup:

build.gradle:
```kt
plugins {
    id("java")
    id("io.freefair.lombok") version "9.5.0"
}

repositories {
    mavenCentral()
}

sourceSets.main {
    java.srcDirs("src/main2/java")
}
```

src/main/java/Main.java:
```java
class Main {
  void doSomething() {}
  void doSomethingElse() {}
}
```

src/main2/java/AnotherClass.java:
```java
class AnotherClass {
  // doesn't need any content
}
```

1. Run `./gradlew delombok` to generate outputs.
2. Now, without modifying AnotherClass, make changes to Main.
3. Re-run `./gradlew delombok` and observe both:
  a. `Task :delombok UP-TO-DATE` in Gradle output.
  b. Build artifacts under `build/generated/sources/delombok/java/main/Main.java` are stale.