### PR TITLE
fix: stop the recurring CodeQL OutOfMemoryError

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 60 }}
     permissions:
       # required for all workflows
       security-events: write
@@ -45,7 +45,7 @@ jobs:
       matrix:
         include:
         - language: java-kotlin
-          build-mode: autobuild
+          build-mode: manual
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -57,6 +57,16 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+
+    # The Java toolchain of this build is 17 and settings.gradle registers no
+    # toolchain resolver, so Gradle cannot provision a JDK itself. Running Gradle
+    # on 17 directly keeps the build off whatever JDKs the runner image happens
+    # to ship.
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5.7.0
+      with:
+        java-version: 17
+        distribution: 'temurin'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -71,20 +81,16 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         queries: security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+    # 'testClasses' is what autobuild compiled here as well, so the scanned scope
+    # is unchanged. The two flags are what make the scan trustworthy:
+    #   --no-daemon        the compiler has to run in the traced process
+    #   --no-build-cache   overrides org.gradle.caching=true. A compile task
+    #                      served from the cache invokes no compiler, the tracer
+    #                      sees nothing, and CodeQL reports a green run over an
+    #                      empty database.
+    - name: Build for CodeQL
+      if: matrix.build-mode == 'manual'
+      run: ./gradlew testClasses --no-daemon --no-build-cache -S
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4.37.7

--- a/examples/gradle.properties
+++ b/examples/gradle.properties
@@ -1,3 +1,8 @@
+# Kept in sync with the root build: Gradle's default 512m daemon heap, which the
+# Kotlin daemon inherits, is too little for the Kotlin compiler.
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m
+kotlin.daemon.jvmargs=-Xmx2g
+
 org.gradle.parallel=true
 org.gradle.caching=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,10 @@
+# The Kotlin daemon inherits -Xmx from the Gradle daemon, and Gradle's default is
+# 512m -- too little for the Kotlin compiler. Cached CI builds never noticed
+# because the compile tasks came from the build cache; CodeQL, which builds
+# uncached, failed with OutOfMemoryError instead.
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m
+kotlin.daemon.jvmargs=-Xmx2g
+
 org.gradle.parallel=true
 org.gradle.caching=true
 


### PR DESCRIPTION
## Problem

`Analyze (java-kotlin)` fails intermittently, most recently on `main` in
[run 33512523694](https://github.com/freefair/gradle-plugins/actions/runs/33512523694)
after 1h20m, and on 2026-08-31 in
[run 33368076297](https://github.com/freefair/gradle-plugins/actions/runs/33368076297).
Same task both times:

```
> Task :quicktype-plugin:compileTestKotlin FAILED
e: java.lang.OutOfMemoryError: Java heap space
> Not enough memory to run compilation. Try to increase it via 'gradle.properties':
  kotlin.daemon.jvmargs=-Xmx<size>
```

Since the job is a required status check, every occurrence blocks merges.

## Root cause

Neither `org.gradle.jvmargs` nor `kotlin.daemon.jvmargs` was set anywhere.
Gradle's daemon therefore defaulted to `-Xmx512m`, and the Kotlin daemon
[inherits `-Xmx` from it](https://kotlinlang.org/docs/gradle-compilation-and-caches.html).
That is not enough for the Kotlin compiler to initialise, even for the ~450
lines of Kotlin in this repository.

It looked flaky because it is really a cache-hit/cache-miss difference: the
regular CI restores `~/.gradle` via `setup-gradle`, so with
`org.gradle.caching=true` the compile tasks come from the build cache and never
run. CodeQL builds uncached and hits the ceiling every time.

## Changes

- **`gradle.properties` (root and `examples/`)** — set `org.gradle.jvmargs` and
  `kotlin.daemon.jvmargs`. Fixing it here rather than in one workflow keeps it
  true for CI on a cache miss and for local builds too.
- **`codeql.yml`** — `build-mode: autobuild` → `manual` with an explicit
  `./gradlew testClasses --no-daemon --no-build-cache -S` and a pinned JDK 17
  (the project toolchain; `settings.gradle` has no toolchain resolver, so Gradle
  cannot provision one itself).

  `--no-build-cache` is deliberate and load-bearing: a compile task served from
  the cache invokes no compiler, the tracer sees nothing, and CodeQL would
  report a **green run over an empty database**. GitHub names Gradle caching as
  a cause of ["No source code was seen during the build"](https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/no-source-code-seen-during-build).
  For the same reason `setup-gradle` is intentionally not used here.

  The task list is what autobuild already compiled, so the scanned scope is
  unchanged.
- **Timeout** for `java-kotlin` from 360 to 60 minutes. A healthy run takes ~7.

## How to verify

Beyond the checks going green, the analysis must not come back empty:

```bash
gh api "/repos/freefair/gradle-plugins/code-scanning/analyses?per_page=5" \
  --jq '.[] | {created_at, ref, results_count, rules_count}'
```

A healthy analysis on `main` reports `rules_count: 240` / `results_count: 54`.
The failed run uploaded `0` / `0`. If this PR's analysis does not report ~240
rules, the build mode is misconfigured and this should not be merged.

Locally `./gradlew assemble` and `./gradlew check` both pass with the new
settings.
